### PR TITLE
Normalize router path handling

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1519,6 +1519,33 @@
       }
     },
 
+    normalizeSlug: (value = '') => {
+      if (typeof value !== 'string') return '';
+      const trimmed = value.trim();
+      if (!trimmed) return '';
+
+      // Remove origin if a full URL is provided
+      let pathname = trimmed;
+      if (/^https?:\/\//i.test(trimmed)) {
+        try {
+          pathname = new URL(trimmed).pathname;
+        } catch (_) {
+          pathname = trimmed;
+        }
+      }
+
+      const stripped = pathname.replace(/^\/+|\/+$/g, '');
+      if (!stripped) return '';
+
+      // Collapse any duplicate slashes between segments
+      return stripped.split('/').filter(Boolean).join('/');
+    },
+
+    normalizePath: (value = '/') => {
+      const slug = Utils.normalizeSlug(value);
+      return slug ? `/${slug}` : '/';
+    },
+
     generateRecipeJsonLd: (recipe) => {
       return {
         "@context": "https://schema.org",
@@ -2083,7 +2110,7 @@
       
       if (!titleEl || !href) return null;
       
-      const slug = href.replace(/^\//, '');
+      const slug = Utils.normalizeSlug(href);
       const name = titleEl.textContent.trim();
       
       return { slug, name };
@@ -2673,25 +2700,24 @@
 
   // ===== ROUTER =====
   const Router = {
-init() {
-  window.addEventListener('popstate', () => {
-    this.render();
-    setTimeout(trackPageView, 0);
-  });
-  this.render();
-  setTimeout(trackPageView, 0); // initial load
-}
-,
+    init() {
+      window.addEventListener('popstate', () => {
+        this.render();
+        setTimeout(trackPageView, 0);
+      });
+      this.render();
+      setTimeout(trackPageView, 0); // initial load
+    },
 
-go(path) {
-  history.pushState({}, '', path);
-  window.scrollTo({ top: 0, behavior: 'smooth' });
-  this.render();
-  // Track after content/title update
-  setTimeout(trackPageView, 0);
-  return false;
-}
-,
+    go(path) {
+      const normalizedPath = Utils.normalizePath(path);
+      history.pushState({}, '', normalizedPath);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      this.render();
+      // Track after content/title update
+      setTimeout(trackPageView, 0);
+      return false;
+    },
 
     render() {
       const year = new Date().getFullYear();
@@ -2701,9 +2727,9 @@ go(path) {
       // Clean up image observers before rendering new content
       ImageManager.cleanup();
 
-      const slug = location.pathname.replace(/^\/+/, '');
+      const slug = Utils.normalizeSlug(location.pathname);
       const filtersEl = Utils.$('#filters');
-      
+
       if (!slug) {
         // Home page - show filters
         if (filtersEl) filtersEl.style.display = 'block';
@@ -2803,7 +2829,7 @@ go(path) {
         KeyboardShortcuts.init();
         Router.init();
         
-        const slug = location.pathname.replace(/^\/+/, '');
+        const slug = Utils.normalizeSlug(location.pathname);
         const filtersEl = Utils.$('#filters');
         if (filtersEl) {
           filtersEl.style.display = slug ? 'none' : 'block';


### PR DESCRIPTION
## Summary
- add shared utilities to normalize slugs and assembled navigation paths
- update router navigation and initialization to rely on normalized paths when rendering views
- normalize href-derived slugs used by the image manager for consistent lazy loading behaviour

## Testing
- Manual verification: used Playwright to navigate with Router.go('/test-slug//') and confirmed window.location.pathname normalizes to '/test-slug'


------
https://chatgpt.com/codex/tasks/task_e_68e18bffc8b0832a898cda97aa053ca2