### PR TITLE
Restrict default CORS wildcard to project previews

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -135,7 +135,7 @@ function corsHeaders(env, origin) {
     'https://elixiary.com',
     'https://www.elixiary.com',
     'https://elixiary.web.app',
-    'https://*.web.app'
+    'https://elixiary--*.web.app'
   ];
 
   const raw = (env.ALLOWED_ORIGINS || '').trim();


### PR DESCRIPTION
## Summary
- replace the blanket https://*.web.app CORS entry with a project-specific preview pattern

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19611240c832a8a812d915e9c3c78