### PR TITLE
Fix production URLs in social meta tags

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -12,7 +12,7 @@
   
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://https://www.elixiary.com/…">
+  <meta property="og:url" content="https://www.elixiary.com/">
   <meta property="og:title" content="Elixiary - Discover Amazing Cocktail Recipes">
   <meta property="og:description" content="Discover and explore an extensive collection of cocktail recipes with detailed ingredients and instructions.">
   <meta property="og:image" content="https://elixiary.web.app/og-image.jpg">
@@ -20,7 +20,7 @@
   
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://elixiary.web.app/">
+  <meta property="twitter:url" content="https://www.elixiary.com/">
   <meta property="twitter:title" content="Elixiary - Discover Amazing Cocktail Recipes">
   <meta property="twitter:description" content="Discover and explore an extensive collection of cocktail recipes with detailed ingredients and instructions.">
   <meta property="twitter:image" content="https://elixiary.web.app/og-image.jpg">
@@ -58,7 +58,7 @@
 <link rel="preconnect" href="https://www.google-analytics.com">
   
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://www.elixiary.com/…">
+  <link rel="canonical" href="https://www.elixiary.com/">
   
   <!-- Resource Hints -->
   <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- point the Open Graph and canonical URLs in dist/index.html to the production https://www.elixiary.com/
- align the Twitter URL meta tag with the production domain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a0390ce0832aae02ddf1f690ee8b