### PR TITLE
Escape placeholder names in SVG

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -2118,6 +2118,10 @@
       const name = recipe?.name || 'Recipe';
       const color = this.getCategoryColor(category);
       
+      const truncatedName = name.substring(0, 20);
+      const displayName = `${truncatedName}${name.length > 20 ? '...' : ''}`;
+      const escapedName = Utils.esc(displayName);
+
       const svg = `
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" style="background:${color}">
           <g transform="translate(100,130)">
@@ -2127,7 +2131,7 @@
             <circle cx="10" cy="-5" r="3" fill="#10B981" fill-opacity="0.9"/>
           </g>
           <text x="100" y="200" text-anchor="middle" fill="white" font-size="12" font-family="system-ui">
-            ${name.substring(0, 20)}${name.length > 20 ? '...' : ''}
+            ${escapedName}
           </text>
         </svg>
       `.trim();


### PR DESCRIPTION
## Summary
- HTML-escape recipe names before embedding them in placeholder SVGs so special characters render correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a5669df0832a907f978e9b9f192e