### PR TITLE
Sort cached sheet index for consistent ordering

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -275,6 +275,12 @@ async function buildIndexFromSheet(env) {
     });
   }
 
+  rows.sort((a, b) => {
+    const dateCmp = String(b.date || '').localeCompare(String(a.date || ''));
+    if (dateCmp !== 0) return dateCmp;
+    return a.slug.localeCompare(b.slug);
+  });
+
   const etag = await hashHex(API_VERSION + ':' + rows.length + ':' + rows.slice(0, 50).map(x => x.slug).join(','));
   return { rows, etag };
 }
@@ -348,8 +354,6 @@ function filterIndex(rows, qRaw, tag, cat, mood) {
   if (tag)  out = out.filter(p => (p.tags || []).map(t => t.toLowerCase()).includes(tag.toLowerCase()));
   if (cat)  out = out.filter(p => String(p.category || '').toLowerCase() === cat.toLowerCase());
   if (mood) out = out.filter(p => (p.mood_labels || []).map(m => m.toLowerCase()).includes(mood.toLowerCase()));
-  // newest first by date (lexicographic ISO)
-  out = out.slice().sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')));
   return out;
 }
 


### PR DESCRIPTION
## Summary
- sort the cached sheet index once in `buildIndexFromSheet` so rows stay in newest-first order
- remove redundant sorting from `filterIndex` to respect the preserved ordering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a8734174832ab76a57510b7948e2