### PR TITLE
Debounce persistent cache writes in ImageManager

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1954,10 +1954,6 @@
       thumb: 'w400-h400',
       detail: 'w1200-h1200'
     },
-    persistentCacheDirty: false,
-    persistentSaveHandle: null,
-    persistentSaveType: null,
-    persistenceEventsBound: false,
     
     // Initialize persistent image cache
     initPersistentCache() {
@@ -2387,6 +2383,11 @@
     }
   }
   };
+
+  ImageManager.persistentCacheDirty = false;
+  ImageManager.persistentSaveHandle = null;
+  ImageManager.persistentSaveType = null;
+  ImageManager.persistenceEventsBound = false;
 
   // ===== UI COMPONENTS =====
   const UIComponents = {

--- a/dist/index.html
+++ b/dist/index.html
@@ -1950,12 +1950,27 @@
     imageCache: new Map(), // Cache for loaded images
     urlCache: new Map(), // Cache for converted URLs
     persistentCache: null, // Persistent localStorage cache
+    persistentCacheDirty: false,
+    persistentSaveHandle: null,
+    persistentSaveType: null,
+    persistenceEventsBound: false,
     
     // Initialize persistent image cache
     initPersistentCache() {
       if (!this.persistentCache) {
         const cached = CacheManager.get('mixology:images');
         this.persistentCache = cached ? new Map(Object.entries(cached.data || {})) : new Map();
+      }
+
+      if (!this.persistenceEventsBound && typeof window !== 'undefined') {
+        this.persistenceEventsBound = true;
+        const flush = () => this.flushPersistentCache();
+        window.addEventListener('beforeunload', flush);
+        document.addEventListener('visibilitychange', () => {
+          if (document.visibilityState === 'hidden') {
+            flush();
+          }
+        });
       }
     },
 
@@ -1964,8 +1979,48 @@
       try {
         const cacheData = Object.fromEntries(this.persistentCache);
         CacheManager.put('mixology:images', { data: cacheData }, 24 * 60 * 60 * 1000); // 24 hours
+        this.persistentCacheDirty = false;
       } catch (error) {
         console.warn('Failed to save image cache:', error);
+      }
+    },
+
+    schedulePersistentSave() {
+      if (this.persistentSaveHandle !== null) {
+        return;
+      }
+
+      const runSave = () => {
+        this.persistentSaveHandle = null;
+        this.persistentSaveType = null;
+        if (this.persistentCacheDirty) {
+          this.savePersistentCache();
+        }
+      };
+
+      if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+        this.persistentSaveType = 'idle';
+        this.persistentSaveHandle = window.requestIdleCallback(runSave);
+      } else {
+        this.persistentSaveType = 'timeout';
+        this.persistentSaveHandle = setTimeout(runSave, 0);
+      }
+    },
+
+    flushPersistentCache() {
+      if (this.persistentSaveHandle !== null) {
+        if (this.persistentSaveType === 'idle' && typeof window !== 'undefined' && typeof window.cancelIdleCallback === 'function') {
+          window.cancelIdleCallback(this.persistentSaveHandle);
+        }
+        if (this.persistentSaveType === 'timeout') {
+          clearTimeout(this.persistentSaveHandle);
+        }
+        this.persistentSaveHandle = null;
+        this.persistentSaveType = null;
+      }
+
+      if (this.persistentCacheDirty) {
+        this.savePersistentCache();
       }
     },
 
@@ -1979,7 +2034,8 @@
     cacheImageUrl(slug, imageUrl) {
       this.initPersistentCache();
       this.persistentCache.set(slug, imageUrl);
-      this.savePersistentCache();
+      this.persistentCacheDirty = true;
+      this.schedulePersistentSave();
     },
 
     convertToDirectImageUrl(url) {

--- a/dist/index.html
+++ b/dist/index.html
@@ -1950,6 +1950,10 @@
     imageCache: new Map(), // Cache for loaded images
     urlCache: new Map(), // Cache for converted URLs
     persistentCache: null, // Persistent localStorage cache
+    sizes: {
+      thumb: 'w400-h400',
+      detail: 'w1200-h1200'
+    },
     persistentCacheDirty: false,
     persistentSaveHandle: null,
     persistentSaveType: null,
@@ -2033,6 +2037,9 @@
     // Cache image URL
     cacheImageUrl(slug, imageUrl) {
       this.initPersistentCache();
+      if (this.persistentCache.get(slug) === imageUrl) {
+        return;
+      }
       this.persistentCache.set(slug, imageUrl);
       this.persistentCacheDirty = true;
       this.schedulePersistentSave();


### PR DESCRIPTION
## Summary
- add scheduling and dirty tracking for ImageManager persistent cache saves
- coalesce rapid cache writes and flush pending data on unload/visibility change

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a8816598832a9a88a5787640409b