### PR TITLE
Adjust detail image layout spacing

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -871,17 +871,32 @@
 
     .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
     @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
-    .detail-rail{ 
-      border:1px solid var(--line-2); 
-      border-radius:18px; 
-      background:var(--soft); 
-      display:grid; 
-      place-items:center;
-      min-height:var(--detailMinH); 
-      overflow:hidden; 
-      box-shadow:var(--shadow); 
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
     }
-    .detail-img{ width:100%; height:100%; object-fit:contain; background:var(--soft); }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
     article{ 
       background:var(--bg); 
       border:1px solid var(--line-2); 


### PR DESCRIPTION
## Summary
- update the recipe detail image rail to size itself to the image instead of a fixed minimum height
- keep the skeleton placeholder height while centering loaded images without console jitter

## Testing
- Not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68e180b5c424832aad65ae592e47041c