### PR TITLE
Fix footer cover image spacing

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1149,6 +1149,7 @@
     .footer {
       margin-top: 80px;
       margin-bottom: 0;
+      padding: 0;
     }
     
     .footer-cover {
@@ -1158,17 +1159,20 @@
       max-height: 600px;
       overflow: hidden;
     }
-    
+
     .cover-image-container {
       position: relative;
       width: 100%;
       height: 100%;
+      overflow: hidden;
     }
-    
+
     .cover-img {
       width: 100%;
       height: 100%;
+      display: block;
       object-fit: cover;
+      object-position: center;
       filter: grayscale(100%) contrast(1.2);
       transition: all 0.8s ease;
     }


### PR DESCRIPTION
## Summary
- remove extra padding from the footer wrapper so the cover image can sit flush with its container
- ensure the cover image container hides overflow and the image itself renders as a block element centered within the frame to eliminate stray whitespace

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68e24fcf1ed0832aa7fee39b8eedb8a1