### PR TITLE
Fix reference error during list rendering

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -2818,7 +2818,7 @@
       const cached = CacheManager.get(firstKey);
       let latestHasMore = (typeof (cached?.has_more) === 'boolean')
         ? cached.has_more
-        : (typeof data.has_more === 'boolean' ? data.has_more : true);
+        : true;
 
       if (reset && cached) {
         AppState.etag = cached.etag || AppState.etag || null;


### PR DESCRIPTION
## Summary
- avoid referencing list data before it is loaded by defaulting to a safe value when checking the cache

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e269f22aac832aadcb1897eaeb60fe