### PR TITLE
Replace service worker registration with unregister on static pages

### DIFF
--- a/dist/contact.html
+++ b/dist/contact.html
@@ -83,7 +83,13 @@
 
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
-    if('serviceWorker' in navigator){ navigator.serviceWorker.register('/sw.js').catch(()=>{}); }
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations()
+        .then((regs) => {
+          for (const reg of regs) reg.unregister();
+        })
+        .catch(() => {});
+    }
     function sendMailto(e){
       e.preventDefault();
       const n = encodeURIComponent(document.getElementById('name').value.trim());

--- a/dist/privacy.html
+++ b/dist/privacy.html
@@ -90,7 +90,13 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
     document.getElementById('updated').textContent = new Date().toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'});
-    if('serviceWorker' in navigator){ navigator.serviceWorker.register('/sw.js').catch(()=>{}); }
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations()
+        .then((regs) => {
+          for (const reg of regs) reg.unregister();
+        })
+        .catch(() => {});
+    }
   </script>
 </body>
 </html>

--- a/dist/terms.html
+++ b/dist/terms.html
@@ -78,7 +78,13 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
     document.getElementById('updated').textContent = new Date().toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'});
-    if('serviceWorker' in navigator){ navigator.serviceWorker.register('/sw.js').catch(()=>{}); }
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations()
+        .then((regs) => {
+          for (const reg of regs) reg.unregister();
+        })
+        .catch(() => {});
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove service worker registration calls from the static privacy, terms, and contact pages
- reuse the unregister-only service worker cleanup logic from the home page for those routes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e27229d068832a8ab6d766bd35fd4f