### PR TITLE
Add Firebase token env to hosting preview workflow

### DIFF
--- a/.github/workflows/hosting-preview.yml
+++ b/.github/workflows/hosting-preview.yml
@@ -21,6 +21,8 @@ jobs:
 
       # Deploy PR to a temporary preview channel
       - name: Deploy preview
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Summary
- add FIREBASE_TOKEN environment variable to the Firebase Hosting preview workflow so deployments have credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27df951f4832aab8e7891e598fa11