### PR TITLE
Restrict preview workflow to non-fork PRs

### DIFF
--- a/.github/workflows/hosting-preview.yml
+++ b/.github/workflows/hosting-preview.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   preview:
+    if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- add a conditional to the Firebase Hosting preview job so it only runs for non-fork pull requests

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e281ba78bc832a952377841bb00a37