### PR TITLE
Handle missing cache when fetching cocktail lists

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -2826,13 +2826,24 @@
         FilterManager.buildChips();
       }
 
-      const data = await APIClient.fetchList({
-        page: 1,
-        ifEtag: cached?.etag || AppState.etag
-      });
+      const ifEtag = cached?.etag ?? null;
+      const requestOptions = { page: 1 };
+      if (ifEtag) {
+        requestOptions.ifEtag = ifEtag;
+      }
+
+      let data = await APIClient.fetchList(requestOptions);
 
       if (requestToken !== AppState.requestId) {
         return;
+      }
+
+      if (data?.not_modified && !cached) {
+        data = await APIClient.fetchList({ page: 1 });
+
+        if (requestToken !== AppState.requestId) {
+          return;
+        }
       }
 
       if (!data.ok) {


### PR DESCRIPTION
## Summary
- update Renderer.renderList to only include if_etag when cached data exists for the current filter
- retry list fetch without if_etag when the API returns not_modified but no cached payload was available

## Testing
- Manual verification: toggled a category filter on and back to All with mocked API responses to ensure cards render

------
https://chatgpt.com/codex/tasks/task_e_68e2b23927e0832a909c2b2f095becef