### PR TITLE
Update worker list ETag hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ Caching:
 
 Worker builds index and stores to KV (key: idx_v1). TTL controlled by CACHE_TTL_SECONDS (default 300 s).
 
-ETag returned by /v1/list to help clients reuse results.
+ETag returned by /v1/list to help clients reuse results. Hash covers API version and canonical row fields (slug, date, category,
+difficulty, prep_time, tags, mood_labels, image links) so any visible change busts caches.
 
 Responses include Cache-Control: public, max-age=60.
 


### PR DESCRIPTION
## Summary
- compute the list index ETag using a SHA-256 digest of canonical user-visible row fields
- document the broader cache-busting coverage in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e942b448832a82b23f143dc7c239