### PR TITLE
Gate analytics loading until consent is granted

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ gtag('event', 'page_view', {
 });
 
 
+Manual QA regression – analytics consent gate (2024-10-20):
+
+- First visit (no stored consent): Launch Chrome DevTools → Network tab, filter for `gtag`/`collect`, then hard-refresh. Confirm the GA network request does **not** appear until clicking **Allow analytics** on the consent banner, after which the script loads immediately.
+- Returning visit (consent granted): With consent stored from the prior step, refresh and confirm the GA script is requested immediately without re-showing the banner.
+
+
 SEO:
 
 Search Console and Bing verified via HTML files in dist/

--- a/dist/assets/analytics.js
+++ b/dist/assets/analytics.js
@@ -48,11 +48,6 @@ function applyConsent(consented) {
   });
 }
 
-const storedConsent = readStoredConsent();
-if (typeof storedConsent === 'boolean') {
-  applyConsent(storedConsent);
-}
-
 function loadAnalyticsLibrary() {
   if (document.getElementById('ga-gtag-script')) return;
   const script = document.createElement('script');
@@ -70,7 +65,13 @@ function loadAnalyticsLibrary() {
   document.head.appendChild(script);
 }
 
-loadAnalyticsLibrary();
+const storedConsent = readStoredConsent();
+if (typeof storedConsent === 'boolean') {
+  applyConsent(storedConsent);
+  if (storedConsent === true) {
+    loadAnalyticsLibrary();
+  }
+}
 
 function showConsentBanner() {
   if (typeof storedConsent === 'boolean') {
@@ -136,6 +137,7 @@ function showConsentBanner() {
   allowBtn.addEventListener('click', () => {
     persistConsent(true);
     applyConsent(true);
+    loadAnalyticsLibrary();
     bar.remove();
   });
 


### PR DESCRIPTION
## Summary
- load the Google Analytics script only when consent is stored as granted and trigger it immediately after opt-in
- document manual QA notes covering regression checks for the analytics consent flow

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3ea16fc40832a8b38a9b3820ee8d4