### PR TITLE
Disable WebKit search cancel affordance

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -550,15 +550,21 @@
     .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
     .search svg{flex:0 0 18px; color:var(--muted)}
     .search input{
-      border:0; 
-      outline:0; 
-      background:transparent; 
-      width:100%; 
-      font-size:14px; 
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
       color:var(--text);
       font-size: 16px; /* Prevent zoom on iOS */
       font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
       font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
     }
     .search input::placeholder {
       color: var(--muted);


### PR DESCRIPTION
## Summary
- hide the native WebKit cancel/decoration affordance on search inputs so only the custom clear button is shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43b4f7c08832abfa15ca66526f03f