### PR TITLE
Hide header search on detail pages

### DIFF
--- a/dist/assets/app.js
+++ b/dist/assets/app.js
@@ -1812,10 +1812,12 @@
 
       const slug = Utils.normalizeSlug(location.pathname);
       const filtersEl = Utils.$('#filters');
+      const searchWrap = Utils.$('.nav-controls .search-wrap');
 
       if (!slug) {
         // Home page - show filters
         if (filtersEl) filtersEl.style.display = 'block';
+        if (searchWrap) searchWrap.style.display = '';
         Utils.setTitle();
         Utils.updateShareUrls();
         return Renderer.renderList(true);
@@ -1830,6 +1832,7 @@
           filtersEl.style.margin = '0';
           filtersEl.style.padding = '0';
         }
+        if (searchWrap) searchWrap.style.display = 'none';
         return Renderer.renderDetail(slug);
       }
     }


### PR DESCRIPTION
## Summary
- hide the header search wrapper when viewing recipe detail routes
- restore the search wrapper display when returning to the home listing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43cc926f4832aacbcc949c73f958f