### PR TITLE
Adjust filter chips layout on mobile

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -875,9 +875,20 @@
     }
 
     @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
       .filter-chips[data-scrollable="true"] {
-        mask-image: linear-gradient(90deg, transparent, rgba(0,0,0,0.85) 32px, rgba(0,0,0,0.85) calc(100% - 32px), transparent);
-        -webkit-mask-image: linear-gradient(90deg, transparent, rgba(0,0,0,0.85) 32px, rgba(0,0,0,0.85) calc(100% - 32px), transparent);
+        mask-image: none;
+        -webkit-mask-image: none;
       }
     }
 


### PR DESCRIPTION
## Summary
- allow filter chip list to wrap with visible overflow and spacing on tablet and smaller viewports
- remove the trailing pseudo-element spacer and gradient mask on small screens to keep chips aligned with the card edges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e53c3e0bb8832a93f8efb94fb74386