### PR TITLE
Fix filter chip layout issues on desktop

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1018,7 +1018,7 @@
 
       .filter-section {
         flex-direction: row;
-        align-items: center;
+        align-items: flex-start;
         gap: 24px;
       }
 
@@ -1038,6 +1038,7 @@
         overflow-x: visible;
         padding-bottom: 0;
         scroll-snap-type: none;
+        min-width: 0;
       }
 
       .filter-chips::after {


### PR DESCRIPTION
## Summary
- align desktop filter sections so chip groups anchor to the top of their rows
- allow filter chip containers to shrink within the panel to avoid overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52de46408832ab502e54aeae62568