### PR TITLE
Improve desktop filter panel scrolling behavior

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1006,6 +1006,8 @@
         padding: 28px 32px;
         gap: 24px;
         max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
       }
 
       .filters-body {
@@ -1030,6 +1032,8 @@
       .filter-groups {
         overflow-y: auto;
         padding-right: 12px;
+        flex: 1;
+        min-height: 0;
       }
 
       .filter-chips {
@@ -1048,6 +1052,9 @@
       .filter-chips[data-scrollable="true"] {
         mask-image: none;
         -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
       }
     }
     


### PR DESCRIPTION
## Summary
- cap desktop filter container overflow so it remains within its max height
- keep filter body/groups flexible with min-height constraints to hold scrollbars inside
- allow scrollable chip sets to scroll vertically within the filter card

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e544fcd69c832ab7dfe204f92f862f