### PR TITLE
Update filter chip scrollable detection

### DIFF
--- a/dist/assets/app.js
+++ b/dist/assets/app.js
@@ -1361,6 +1361,8 @@
   };
 
   const FilterManager = {
+    _scrollableResizeHandler: null,
+    _scrollableResizeListenerAttached: false,
     reset() {
       AppState.filterSets = AppState.filterSets || {};
       AppState.filterSignatures = AppState.filterSignatures || {};
@@ -1454,6 +1456,8 @@
 
       this.setupSearchHandlers();
       AppState.chipsBuilt = true;
+      this.refreshAllScrollableStates();
+      this.ensureScrollableResizeListener();
       this.renderActiveFilters();
     },
 
@@ -1500,13 +1504,6 @@
         sanitizedItems.push({ value: chipValue, label: chipLabel });
       });
 
-      const isScrollable = sanitizedItems.length > (effectiveConfig.scrollThreshold ?? 8);
-      if (container.dataset && typeof container.dataset === 'object') {
-        container.dataset.scrollable = isScrollable ? 'true' : 'false';
-      } else if (typeof container.setAttribute === 'function') {
-        container.setAttribute('data-scrollable', isScrollable ? 'true' : 'false');
-      }
-
       const ariaFn = typeof effectiveConfig.ariaLabel === 'function'
         ? effectiveConfig.ariaLabel
         : (label) => `Filter by ${key}: ${label}`;
@@ -1539,6 +1536,50 @@
       });
 
       container.innerHTML = chips.join('');
+      this.measureChipScrollState(container);
+    },
+
+    measureChipScrollState(container) {
+      if (!container) return;
+
+      const applyMeasurement = () => {
+        const el = container;
+        if (!el) return;
+        const scrollable = Math.ceil(el.scrollHeight || 0) > Math.ceil(el.clientHeight || 0);
+        if (el.dataset && typeof el.dataset === 'object') {
+          el.dataset.scrollable = scrollable ? 'true' : 'false';
+        } else if (typeof el.setAttribute === 'function') {
+          el.setAttribute('data-scrollable', scrollable ? 'true' : 'false');
+        }
+      };
+
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(applyMeasurement);
+      } else {
+        applyMeasurement();
+      }
+    },
+
+    refreshAllScrollableStates() {
+      for (const [key, config] of Object.entries(FILTER_GROUP_DEFS)) {
+        const selector = (config && config.selector) || `#${key}`;
+        const container = Utils.$(selector);
+        if (container) {
+          this.measureChipScrollState(container);
+        }
+      }
+    },
+
+    ensureScrollableResizeListener() {
+      if (this._scrollableResizeListenerAttached || typeof window === 'undefined') return;
+
+      const handler = Utils.debounce(() => {
+        this.refreshAllScrollableStates();
+      }, CONFIG.DEBOUNCE_MS);
+
+      window.addEventListener('resize', handler);
+      this._scrollableResizeHandler = handler;
+      this._scrollableResizeListenerAttached = true;
     },
 
     normalizeValue(value, key, configOverride) {


### PR DESCRIPTION
## Summary
- measure filter chip groups after rendering and set `data-scrollable` based on actual overflow
- add helpers to recalculate scrollability after chip rebuilds and on viewport resize events

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e54717cbe0832ab3d5f16a1c664383