### PR TITLE
Refine mobile navigation stacking

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -331,11 +331,13 @@
     /* Mobile navbar optimization */
     @media (max-width: 768px) {
       .nav {
-        height: 60px;
-        gap: 12px;
-        padding: 0 16px;
+        height: auto;
+        flex-direction: column;
+        align-items: stretch;
+        row-gap: 12px;
+        padding: 12px 16px;
       }
-      
+
       .brand {
         min-width: 0;
         flex-shrink: 0;
@@ -363,11 +365,20 @@
         display: none; /* Hide subtitle on mobile */
       }
       
-      .nav-controls { gap: 12px; }
+      .nav-controls {
+        display: grid;
+        width: 100%;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 12px;
+        align-items: center;
+      }
       .search-wrap {
-        flex: 1;
+        width: 100%;
         min-width: 0;
-        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control {
+        flex: 0 0 auto;
+        justify-self: end;
       }
       .theme-control label {
         display: none;
@@ -402,9 +413,9 @@
 
     @media (max-width: 480px) {
       .nav {
-        height: 56px;
-        gap: 8px;
-        padding: 0 12px;
+        height: auto;
+        row-gap: 8px;
+        padding: 12px;
       }
 
       .nav-controls {
@@ -430,7 +441,8 @@
       }
 
       .search-wrap {
-        max-width: calc(100% - 120px - 8px);
+        width: 100%;
+        min-width: 0;
       }
       
       .search {
@@ -462,9 +474,9 @@
 
     @media (max-width: 360px) {
       .nav {
-        height: 52px;
-        gap: 6px;
-        padding: 0 8px;
+        height: auto;
+        row-gap: 6px;
+        padding: 12px 8px;
       }
 
       .nav-controls {
@@ -485,7 +497,8 @@
       }
 
       .search-wrap {
-        max-width: calc(100% - 120px - 6px);
+        width: 100%;
+        min-width: 0;
       }
 
       .search {


### PR DESCRIPTION
## Summary
- allow the navigation bar to stack vertically on small screens so the height expands with the content
- convert the mobile nav controls into a responsive two-column grid and let the search field fill the first track
- keep the theme selector compact while updating smaller breakpoints to prevent overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5825e5cf8832a9f5c443d316687e3