### PR TITLE
Fix canonical URLs on static support pages

### DIFF
--- a/dist/contact.html
+++ b/dist/contact.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; script-src 'self'; connect-src 'self';">
-  <link rel="canonical" href="https://elixiary.web.app/contact">
+  <link rel="canonical" href="https://www.elixiary.com/contact">
   <style>
     :root{--bg:#fff;--text:#0B0F19;--muted:#6B7280;--line:#E5E7EB;--soft:#F7F8FA;--accent:#111827;--radius:14px;}
     *{box-sizing:border-box} body{margin:0;font-family:"Plus Jakarta Sans",ui-sans-serif,-apple-system,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--text);}

--- a/dist/privacy.html
+++ b/dist/privacy.html
@@ -19,7 +19,7 @@
   <!-- CSP (same style as index, no API calls here) -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; script-src 'self'; connect-src 'self';">
 
-  <link rel="canonical" href="https://elixiary.web.app/privacy">
+  <link rel="canonical" href="https://www.elixiary.com/privacy">
 
   <style>
     :root{--bg:#fff;--text:#0B0F19;--muted:#6B7280;--line:#E5E7EB;--soft:#F7F8FA;--accent:#111827;--radius:14px;}

--- a/dist/terms.html
+++ b/dist/terms.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; script-src 'self'; connect-src 'self';">
-  <link rel="canonical" href="https://elixiary.web.app/terms">
+  <link rel="canonical" href="https://www.elixiary.com/terms">
   <style>
     :root{--bg:#fff;--text:#0B0F19;--muted:#6B7280;--line:#E5E7EB;--soft:#F7F8FA;--accent:#111827;--radius:14px;}
     *{box-sizing:border-box} body{margin:0;font-family:"Plus Jakarta Sans",ui-sans-serif,-apple-system,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--text);}


### PR DESCRIPTION
## Summary
- update the canonical link element on the contact, privacy, and terms static pages to use the https://www.elixiary.com domain

## Testing
- `rg "canonical" dist/contact.html dist/privacy.html dist/terms.html`
- `for page in contact privacy terms; do curl -s "file:///workspace/elixiary/dist/${page}.html" | grep canonical; done`


------
https://chatgpt.com/codex/tasks/task_e_68e584238cd0832a80dbe15605342a85