### PR TITLE
Switch sitemap to canonical www host

### DIFF
--- a/dist/robots.txt
+++ b/dist/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://elixiary.com/sitemap.xml
+Sitemap: https://www.elixiary.com/sitemap.xml

--- a/dist/sitemap.xml
+++ b/dist/sitemap.xml
@@ -4,86 +4,86 @@
 
   <!-- Core pages -->
   <url>
-    <loc>https://elixiary.com/</loc>
+    <loc>https://www.elixiary.com/</loc>
     <lastmod>2025-09-21</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://elixiary.com/privacy</loc>
+    <loc>https://www.elixiary.com/privacy</loc>
     <lastmod>2025-09-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://elixiary.com/terms</loc>
+    <loc>https://www.elixiary.com/terms</loc>
     <lastmod>2025-09-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://elixiary.com/contact</loc>
+    <loc>https://www.elixiary.com/contact</loc>
     <lastmod>2025-09-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <!-- Recipes -->
-  <url><loc>https://elixiary.com/252</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/747</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/110-in-the-shade</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/151-florida-bushwacker</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/155-belmont</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/1800-coco-pinarita</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/24k-nightmare</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/3-wise-men</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/3-mile-long-island-iced-tea</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/410-gone</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/50-50</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/501-blue</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/57-chevy-with-a-white-license-plate</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/69-special</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/747-drink</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/9-1-2-weeks</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/a-j</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/a1</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/aam-panna</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/aamras</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/abc</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/abilene</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/acapulco</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/ace</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/acid</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/across-the-pacific</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/adam</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/addington</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/addison</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/adios-motherfucker-amf</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/adonis</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/adult-hot-chocolate</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/affair</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/affinity</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/affogato</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/afterglow</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/agua-de-bandindo</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/agua-de-valencia</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/aguapanela</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/airmail</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/ajoblanco</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/alexander</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/algonquin</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/alien-brain-hemorrhage</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/allegheny</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/almeria</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/almond-banana-smoothie</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/amaretto-sour</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/amarula-thai-tea</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/american-trilogy</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/americano</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/amritulya-chai</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/angel-face</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/angevine-soup</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/apello</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://elixiary.com/aperol-spritz</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/252</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/747</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/110-in-the-shade</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/151-florida-bushwacker</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/155-belmont</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/1800-coco-pinarita</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/24k-nightmare</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/3-wise-men</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/3-mile-long-island-iced-tea</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/410-gone</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/50-50</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/501-blue</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/57-chevy-with-a-white-license-plate</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/69-special</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/747-drink</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/9-1-2-weeks</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/a-j</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/a1</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/aam-panna</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/aamras</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/abc</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/abilene</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/acapulco</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/ace</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/acid</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/across-the-pacific</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/adam</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/addington</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/addison</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/adios-motherfucker-amf</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/adonis</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/adult-hot-chocolate</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/affair</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/affinity</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/affogato</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/afterglow</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/agua-de-bandindo</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/agua-de-valencia</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/aguapanela</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/airmail</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/ajoblanco</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/alexander</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/algonquin</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/alien-brain-hemorrhage</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/allegheny</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/almeria</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/almond-banana-smoothie</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/amaretto-sour</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/amarula-thai-tea</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/american-trilogy</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/americano</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/amritulya-chai</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/angel-face</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/angevine-soup</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/apello</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.elixiary.com/aperol-spritz</loc><lastmod>2025-09-21</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
 
 </urlset>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "description": "Build-time utilities for the Elixiary static site",
   "scripts": {
-    "prerender": "node scripts/prerender-home.js"
+    "prerender": "node scripts/prerender-home.js",
+    "postprerender": "node scripts/update-canonical-domain.js"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",

--- a/scripts/update-canonical-domain.js
+++ b/scripts/update-canonical-domain.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const fs = require('fs/promises');
+const path = require('path');
+
+const DIST_DIR = path.join(__dirname, '..', 'dist');
+const SITEMAP_PATH = path.join(DIST_DIR, 'sitemap.xml');
+const ROBOTS_PATH = path.join(DIST_DIR, 'robots.txt');
+const CANONICAL_ORIGIN = 'https://www.elixiary.com';
+
+async function updateSitemap() {
+  const original = await fs.readFile(SITEMAP_PATH, 'utf8');
+  const updated = original.replace(/(<loc>https:\/\/)(?:www\.)?elixiary\.com/gi, `$1www.elixiary.com`);
+  if (updated !== original) {
+    await fs.writeFile(SITEMAP_PATH, updated);
+  }
+}
+
+async function updateRobots() {
+  const original = await fs.readFile(ROBOTS_PATH, 'utf8');
+  const updated = original.replace(/Sitemap:\s+https:\/\/(?:www\.)?elixiary\.com\/sitemap\.xml/gi, `Sitemap: ${CANONICAL_ORIGIN}/sitemap.xml`);
+  if (updated !== original) {
+    await fs.writeFile(ROBOTS_PATH, updated);
+  }
+}
+
+(async () => {
+  try {
+    await Promise.all([updateSitemap(), updateRobots()]);
+    console.log('Canonical domain updated in sitemap.xml and robots.txt');
+  } catch (error) {
+    console.error('Failed to update canonical domain metadata');
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a post-prerender script that enforces the https://www.elixiary.com canonical origin in sitemap.xml and robots.txt
- update the generated sitemap and robots files to reference the www host

## Testing
- npm run prerender

------
https://chatgpt.com/codex/tasks/task_e_68e58a2fdf44832ab9032584ad0b4611