### PR TITLE
Pre-render recipe detail pages and adjust hosting rewrites

### DIFF
--- a/dist/french-pearl/index.html
+++ b/dist/french-pearl/index.html
@@ -1,0 +1,1921 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>French Pearl · Elixiary</title>
+  <meta name="description" content="Muddle mint leaves with simple syrup in a shaker, then add gin, fresh lime juice, and absinthe. Shake well with ice and fine strain into a chilled coupe.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/french-pearl">
+  <meta property="og:title" content="French Pearl · Elixiary">
+  <meta property="og:description" content="Muddle mint leaves with simple syrup in a shaker, then add gin, fresh lime juice, and absinthe. Shake well with ice and fine strain into a chilled coupe.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1es6LFkJovPLcfnclBykQ2zdt-ksMKKRo">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/french-pearl">
+  <meta name="twitter:title" content="French Pearl · Elixiary">
+  <meta name="twitter:description" content="Muddle mint leaves with simple syrup in a shaker, then add gin, fresh lime juice, and absinthe. Shake well with ice and fine strain into a chilled coupe.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1es6LFkJovPLcfnclBykQ2zdt-ksMKKRo">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/french-pearl">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/french-pearl",
+      "url": "https://www.elixiary.com/french-pearl",
+      "name": "French Pearl",
+      "description": "Muddle mint leaves with simple syrup in a shaker, then add gin, fresh lime juice, and absinthe. Shake well with ice and fine strain into a chilled coupe.",
+      "image": "https://drive.google.com/uc?export=view&id=1es6LFkJovPLcfnclBykQ2zdt-ksMKKRo",
+      "datePublished": "2025-09-29",
+      "prepTime": "4 minutes",
+      "recipeCategory": "Short Shaken Citrus",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "Gin",
+        "Simple Syrup",
+        "Fresh Lime Juice",
+        "Mint Leaf",
+        "Absinthe"
+      ],
+      "recipeInstructions": "Muddle mint leaves with simple syrup in a shaker, then add gin, fresh lime juice, and absinthe. Shake well with ice and fine strain into a chilled coupe.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Contemporary Classic",
+        "Citrus",
+        "Fruity",
+        "Serve Up",
+        "Light Refreshing",
+        "Time Aperitif"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>French Pearl</h1>
+          <div class="info">Sep 29, 2025 · Medium · 4 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>Gin</li><li>Simple Syrup</li><li>Fresh Lime Juice</li><li>Mint Leaf</li><li>Absinthe</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Short Shaken Citrus</div>
+                <div class="kv"><b>Glass</b> Coffee Mug</div>
+                <div class="kv"><b>Garnish</b> Mint Sprig</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Muddle mint leaves with simple syrup in a shaker, then add gin, fresh lime juice, and absinthe. Shake well with ice and fine strain into a chilled coupe.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Contemporary Classic</span><span class="pill">Citrus</span><span class="pill">Fruity</span><span class="pill">Serve Up</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Time Aperitif</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1es6LFkJovPLcfnclBykQ2zdt-ksMKKRo" data-alt="https://drive.google.com/thumbnail?id=1es6LFkJovPLcfnclBykQ2zdt-ksMKKRo&amp;sz=w1200" alt="French Pearl" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/french-sangria/index.html
+++ b/dist/french-sangria/index.html
@@ -1,0 +1,1925 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>French Sangria · Elixiary</title>
+  <meta name="description" content="In a large pitcher, combine red wine, brandy, simple syrup, lime juice, and Provençale blend. Add thinly sliced orange, lime, and seasonal fruits, then stir gently. Top with lemon soda before servi…">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/french-sangria">
+  <meta property="og:title" content="French Sangria · Elixiary">
+  <meta property="og:description" content="In a large pitcher, combine red wine, brandy, simple syrup, lime juice, and Provençale blend. Add thinly sliced orange, lime, and seasonal fruits, then stir gently. Top with lemon soda before servi…">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1kv1QKBzo6yZJvNIfpmTUcr4aO78mgnp2">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/french-sangria">
+  <meta name="twitter:title" content="French Sangria · Elixiary">
+  <meta name="twitter:description" content="In a large pitcher, combine red wine, brandy, simple syrup, lime juice, and Provençale blend. Add thinly sliced orange, lime, and seasonal fruits, then stir gently. Top with lemon soda before servi…">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1kv1QKBzo6yZJvNIfpmTUcr4aO78mgnp2">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/french-sangria">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/french-sangria",
+      "url": "https://www.elixiary.com/french-sangria",
+      "name": "French Sangria",
+      "description": "In a large pitcher, combine red wine, brandy, simple syrup, lime juice, and Provençale blend. Add thinly sliced orange, lime, and seasonal fruits, then stir gently. Top with lemon soda before servi…",
+      "image": "https://drive.google.com/uc?export=view&id=1kv1QKBzo6yZJvNIfpmTUcr4aO78mgnp2",
+      "datePublished": "2025-09-29",
+      "prepTime": "2 minutes",
+      "recipeCategory": "Punch Party",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "Red wine",
+        "Brandy",
+        "Simple syrup",
+        "Lime juice",
+        "Orange",
+        "Lime",
+        "Peach / nectarine / other seasonal fruits thinly sliced",
+        "Provençale blend",
+        "Lemon soda"
+      ],
+      "recipeInstructions": "In a large pitcher, combine red wine, brandy, simple syrup, lime juice, and Provençale blend. Add thinly sliced orange, lime, and seasonal fruits, then stir gently. Top with lemon soda before serving over ice.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Spritz",
+        "Fruity",
+        "Season Summer",
+        "Party",
+        "Light Refreshing",
+        "Time Aperitif"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>French Sangria</h1>
+          <div class="info">Sep 29, 2025 · Easy · 2 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>Red wine</li><li>Brandy</li><li>Simple syrup</li><li>Lime juice</li><li>Orange</li><li>Lime</li><li>Peach / nectarine / other seasonal fruits thinly sliced</li><li>Provençale blend</li><li>Lemon soda</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Punch Party</div>
+                <div class="kv"><b>Glass</b> Coffee Mug</div>
+                <div class="kv"><b>Garnish</b> Orange Slice + Lime Wheel</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>In a large pitcher, combine red wine, brandy, simple syrup, lime juice, and Provençale blend. Add thinly sliced orange, lime, and seasonal fruits, then stir gently. Top with lemon soda before serving over ice.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Spritz</span><span class="pill">Fruity</span><span class="pill">Season Summer</span><span class="pill">Party</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Time Aperitif</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1kv1QKBzo6yZJvNIfpmTUcr4aO78mgnp2" data-alt="https://drive.google.com/thumbnail?id=1kv1QKBzo6yZJvNIfpmTUcr4aO78mgnp2&amp;sz=w1200" alt="French Sangria" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/frisco-sour/index.html
+++ b/dist/frisco-sour/index.html
@@ -1,0 +1,1922 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Frisco Sour · Elixiary</title>
+  <meta name="description" content="Combine blended whiskey, Benedictine, lemon juice, and lime juice with ice, then fine strain into a whiskey sour glass. Garnish with a slice of lemon and a slice of lime.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/frisco-sour">
+  <meta property="og:title" content="Frisco Sour · Elixiary">
+  <meta property="og:description" content="Combine blended whiskey, Benedictine, lemon juice, and lime juice with ice, then fine strain into a whiskey sour glass. Garnish with a slice of lemon and a slice of lime.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1rh-rJd7RULo6rfQtijMJP3OzaJ3tNG5s">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/frisco-sour">
+  <meta name="twitter:title" content="Frisco Sour · Elixiary">
+  <meta name="twitter:description" content="Combine blended whiskey, Benedictine, lemon juice, and lime juice with ice, then fine strain into a whiskey sour glass. Garnish with a slice of lemon and a slice of lime.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1rh-rJd7RULo6rfQtijMJP3OzaJ3tNG5s">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/frisco-sour">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/frisco-sour",
+      "url": "https://www.elixiary.com/frisco-sour",
+      "name": "Frisco Sour",
+      "description": "Combine blended whiskey, Benedictine, lemon juice, and lime juice with ice, then fine strain into a whiskey sour glass. Garnish with a slice of lemon and a slice of lime.",
+      "image": "https://drive.google.com/uc?export=view&id=1rh-rJd7RULo6rfQtijMJP3OzaJ3tNG5s",
+      "datePublished": "2025-09-29",
+      "prepTime": "3 minutes",
+      "recipeCategory": "Short Shaken Citrus",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "2 oz Blended whiskey",
+        "1/2 oz Benedictine",
+        "Juice of 1/4 Lemon",
+        "Juice of 1/2 Lime",
+        "1 slice Lemon",
+        "1 slice Lime"
+      ],
+      "recipeInstructions": "Combine blended whiskey, Benedictine, lemon juice, and lime juice with ice, then fine strain into a whiskey sour glass. Garnish with a slice of lemon and a slice of lime.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Classic",
+        "Sour Family",
+        "Citrus",
+        "Moderate",
+        "Bold Spirit Forward",
+        "Time Nightcap"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Frisco Sour</h1>
+          <div class="info">Sep 29, 2025 · Medium · 3 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>2 oz Blended whiskey</li><li>1/2 oz Benedictine</li><li>Juice of 1/4 Lemon</li><li>Juice of 1/2 Lime</li><li>1 slice Lemon</li><li>1 slice Lime</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Short Shaken Citrus</div>
+                <div class="kv"><b>Glass</b> Rocks</div>
+                <div class="kv"><b>Garnish</b> Lemon Wheel + Lime Wheel</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Combine blended whiskey, Benedictine, lemon juice, and lime juice with ice, then fine strain into a whiskey sour glass. Garnish with a slice of lemon and a slice of lime.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Classic</span><span class="pill">Sour Family</span><span class="pill">Citrus</span><span class="pill">Moderate</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Bold Spirit Forward</span><span class="pill">Time Nightcap</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1rh-rJd7RULo6rfQtijMJP3OzaJ3tNG5s" data-alt="https://drive.google.com/thumbnail?id=1rh-rJd7RULo6rfQtijMJP3OzaJ3tNG5s&amp;sz=w1200" alt="Frisco Sour" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/frose/index.html
+++ b/dist/frose/index.html
@@ -1,0 +1,1920 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Frosé · Elixiary</title>
+  <meta name="description" content="Freeze rosé in a 13x9&quot; pan until nearly solid, at least 6 hours. Boil sugar with ½ cup water until dissolved, then add strawberries and let infuse for 30 minutes; strain and chill. Blend frozen ros…">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/frose">
+  <meta property="og:title" content="Frosé · Elixiary">
+  <meta property="og:description" content="Freeze rosé in a 13x9&quot; pan until nearly solid, at least 6 hours. Boil sugar with ½ cup water until dissolved, then add strawberries and let infuse for 30 minutes; strain and chill. Blend frozen ros…">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1GDlFqypYurhaG5Dn-HD9gf_lwYLrlD5w">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/frose">
+  <meta name="twitter:title" content="Frosé · Elixiary">
+  <meta name="twitter:description" content="Freeze rosé in a 13x9&quot; pan until nearly solid, at least 6 hours. Boil sugar with ½ cup water until dissolved, then add strawberries and let infuse for 30 minutes; strain and chill. Blend frozen ros…">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1GDlFqypYurhaG5Dn-HD9gf_lwYLrlD5w">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/frose">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/frose",
+      "url": "https://www.elixiary.com/frose",
+      "name": "Frosé",
+      "description": "Freeze rosé in a 13x9\" pan until nearly solid, at least 6 hours. Boil sugar with ½ cup water until dissolved, then add strawberries and let infuse for 30 minutes; strain and chill. Blend frozen ros…",
+      "image": "https://drive.google.com/uc?export=view&id=1GDlFqypYurhaG5Dn-HD9gf_lwYLrlD5w",
+      "datePublished": "2025-09-29",
+      "prepTime": "8 minutes",
+      "recipeCategory": "Frozen Blended",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "750 ml Rose",
+        "1/2 cup Sugar",
+        "8 oz Strawberries",
+        "2-3 oz Lemon Juice"
+      ],
+      "recipeInstructions": "Freeze rosé in a 13x9\" pan until nearly solid, at least 6 hours. Boil sugar with ½ cup water until dissolved, then add strawberries and let infuse for 30 minutes; strain and chill. Blend frozen rosé with lemon juice, 3½ ounces strawberry syrup, and 1 cup crushed ice until smooth, then freeze until thickened, about 25–35 minutes. Blend again for a slushy texture and serve in cocktail glasses.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Spritz",
+        "Fruity",
+        "Season Summer",
+        "Serve Frozen",
+        "Light Refreshing",
+        "Bright Uplifting"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Frosé</h1>
+          <div class="info">Sep 29, 2025 · Hard · 8 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>750 ml Rose</li><li>1/2 cup Sugar</li><li>8 oz Strawberries</li><li>2-3 oz Lemon Juice</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Frozen Blended</div>
+                <div class="kv"><b>Glass</b> Martini</div>
+                <div class="kv"><b>Garnish</b> None</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Freeze rosé in a 13x9" pan until nearly solid, at least 6 hours. Boil sugar with ½ cup water until dissolved, then add strawberries and let infuse for 30 minutes; strain and chill. Blend frozen rosé with lemon juice, 3½ ounces strawberry syrup, and 1 cup crushed ice until smooth, then freeze until thickened, about 25–35 minutes. Blend again for a slushy texture and serve in cocktail glasses.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Spritz</span><span class="pill">Fruity</span><span class="pill">Season Summer</span><span class="pill">Serve Frozen</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Bright Uplifting</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1GDlFqypYurhaG5Dn-HD9gf_lwYLrlD5w" data-alt="https://drive.google.com/thumbnail?id=1GDlFqypYurhaG5Dn-HD9gf_lwYLrlD5w&amp;sz=w1200" alt="Frosé" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/frosted-lemonade/index.html
+++ b/dist/frosted-lemonade/index.html
@@ -1,0 +1,1921 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Frosted Lemonade · Elixiary</title>
+  <meta name="description" content="Blend freshly squeezed lemon juice, sugar, water, and vanilla ice cream until smooth. Serve immediately in a chilled glass.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/frosted-lemonade">
+  <meta property="og:title" content="Frosted Lemonade · Elixiary">
+  <meta property="og:description" content="Blend freshly squeezed lemon juice, sugar, water, and vanilla ice cream until smooth. Serve immediately in a chilled glass.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1SEvorCizc_GrIEXtd9yGqcmSr7qmH_tw">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/frosted-lemonade">
+  <meta name="twitter:title" content="Frosted Lemonade · Elixiary">
+  <meta name="twitter:description" content="Blend freshly squeezed lemon juice, sugar, water, and vanilla ice cream until smooth. Serve immediately in a chilled glass.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1SEvorCizc_GrIEXtd9yGqcmSr7qmH_tw">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/frosted-lemonade">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/frosted-lemonade",
+      "url": "https://www.elixiary.com/frosted-lemonade",
+      "name": "Frosted Lemonade",
+      "description": "Blend freshly squeezed lemon juice, sugar, water, and vanilla ice cream until smooth. Serve immediately in a chilled glass.",
+      "image": "https://drive.google.com/uc?export=view&id=1SEvorCizc_GrIEXtd9yGqcmSr7qmH_tw",
+      "datePublished": "2025-09-29",
+      "prepTime": "5 minutes",
+      "recipeCategory": "Soft Zero Proof",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "freshly squeezed lemon juice",
+        "sugar",
+        "water",
+        "vanilla ice cream"
+      ],
+      "recipeInstructions": "Blend freshly squeezed lemon juice, sugar, water, and vanilla ice cream until smooth. Serve immediately in a chilled glass.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Contemporary Classic",
+        "Citrus",
+        "Diet Dairy",
+        "Texture Creamy",
+        "Serve Frozen",
+        "Light Refreshing",
+        "Time Sundowner"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Frosted Lemonade</h1>
+          <div class="info">Sep 29, 2025 · Medium · 5 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>freshly squeezed lemon juice</li><li>sugar</li><li>water</li><li>vanilla ice cream</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Soft Zero Proof</div>
+                <div class="kv"><b>Glass</b> Coffee Mug</div>
+                <div class="kv"><b>Garnish</b> None</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Blend freshly squeezed lemon juice, sugar, water, and vanilla ice cream until smooth. Serve immediately in a chilled glass.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Contemporary Classic</span><span class="pill">Citrus</span><span class="pill">Diet Dairy</span><span class="pill">Texture Creamy</span><span class="pill">Serve Frozen</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Time Sundowner</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1SEvorCizc_GrIEXtd9yGqcmSr7qmH_tw" data-alt="https://drive.google.com/thumbnail?id=1SEvorCizc_GrIEXtd9yGqcmSr7qmH_tw&amp;sz=w1200" alt="Frosted Lemonade" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/frozen-cantaloupe-margarita/index.html
+++ b/dist/frozen-cantaloupe-margarita/index.html
@@ -1,0 +1,1924 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Frozen Cantaloupe Margarita · Elixiary</title>
+  <meta name="description" content="Blend frozen cantaloupes, coconut milk, silver tequila, lime juice, Cointreau, and agave or honey until smooth. Optionally, rim a glass with salt and pour the mixture in.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/frozen-cantaloupe-margarita">
+  <meta property="og:title" content="Frozen Cantaloupe Margarita · Elixiary">
+  <meta property="og:description" content="Blend frozen cantaloupes, coconut milk, silver tequila, lime juice, Cointreau, and agave or honey until smooth. Optionally, rim a glass with salt and pour the mixture in.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1Yc_BKspz_ajI1G45HLtO-g6QQe2XsfFn">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/frozen-cantaloupe-margarita">
+  <meta name="twitter:title" content="Frozen Cantaloupe Margarita · Elixiary">
+  <meta name="twitter:description" content="Blend frozen cantaloupes, coconut milk, silver tequila, lime juice, Cointreau, and agave or honey until smooth. Optionally, rim a glass with salt and pour the mixture in.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1Yc_BKspz_ajI1G45HLtO-g6QQe2XsfFn">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/frozen-cantaloupe-margarita">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/frozen-cantaloupe-margarita",
+      "url": "https://www.elixiary.com/frozen-cantaloupe-margarita",
+      "name": "Frozen Cantaloupe Margarita",
+      "description": "Blend frozen cantaloupes, coconut milk, silver tequila, lime juice, Cointreau, and agave or honey until smooth. Optionally, rim a glass with salt and pour the mixture in.",
+      "image": "https://drive.google.com/uc?export=view&id=1Yc_BKspz_ajI1G45HLtO-g6QQe2XsfFn",
+      "datePublished": "2025-09-29",
+      "prepTime": "5 minutes",
+      "recipeCategory": "Frozen Blended",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "frozen cantaloupes",
+        "unsweetened coconut milk",
+        "silver tequila",
+        "lime juice",
+        "Cointreau",
+        "agave or honey to taste",
+        "Optional: salt, for the rims"
+      ],
+      "recipeInstructions": "Blend frozen cantaloupes, coconut milk, silver tequila, lime juice, Cointreau, and agave or honey until smooth. Optionally, rim a glass with salt and pour the mixture in.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "New Era",
+        "Serve Frozen",
+        "Citrus",
+        "Diet Dairy",
+        "Brunch",
+        "Light Refreshing",
+        "Season Tropical"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Frozen Cantaloupe Margarita</h1>
+          <div class="info">Sep 29, 2025 · Medium · 5 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>frozen cantaloupes</li><li>unsweetened coconut milk</li><li>silver tequila</li><li>lime juice</li><li>Cointreau</li><li>agave or honey to taste</li><li>Optional: salt, for the rims</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Frozen Blended</div>
+                <div class="kv"><b>Glass</b> Coffee Mug</div>
+                <div class="kv"><b>Garnish</b> Lime Wedge</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Blend frozen cantaloupes, coconut milk, silver tequila, lime juice, Cointreau, and agave or honey until smooth. Optionally, rim a glass with salt and pour the mixture in.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">New Era</span><span class="pill">Serve Frozen</span><span class="pill">Citrus</span><span class="pill">Diet Dairy</span><span class="pill">Brunch</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Season Tropical</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1Yc_BKspz_ajI1G45HLtO-g6QQe2XsfFn" data-alt="https://drive.google.com/thumbnail?id=1Yc_BKspz_ajI1G45HLtO-g6QQe2XsfFn&amp;sz=w1200" alt="Frozen Cantaloupe Margarita" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/frozen-daiquiri/index.html
+++ b/dist/frozen-daiquiri/index.html
@@ -1,0 +1,1923 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Frozen Daiquiri · Elixiary</title>
+  <meta name="description" content="Blend 1 1/2 oz light rum, 1 tbsp triple sec, 1 1/2 oz lime juice, 1 tsp sugar, and 1 cup crushed ice on low for five seconds, then on high until firm. Pour into a champagne flute, garnish with a ch…">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/frozen-daiquiri">
+  <meta property="og:title" content="Frozen Daiquiri · Elixiary">
+  <meta property="og:description" content="Blend 1 1/2 oz light rum, 1 tbsp triple sec, 1 1/2 oz lime juice, 1 tsp sugar, and 1 cup crushed ice on low for five seconds, then on high until firm. Pour into a champagne flute, garnish with a ch…">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1N4jGKOGOHhcGAR_4ur01aFxHpvW_RFt5">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/frozen-daiquiri">
+  <meta name="twitter:title" content="Frozen Daiquiri · Elixiary">
+  <meta name="twitter:description" content="Blend 1 1/2 oz light rum, 1 tbsp triple sec, 1 1/2 oz lime juice, 1 tsp sugar, and 1 cup crushed ice on low for five seconds, then on high until firm. Pour into a champagne flute, garnish with a ch…">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1N4jGKOGOHhcGAR_4ur01aFxHpvW_RFt5">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/frozen-daiquiri">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/frozen-daiquiri",
+      "url": "https://www.elixiary.com/frozen-daiquiri",
+      "name": "Frozen Daiquiri",
+      "description": "Blend 1 1/2 oz light rum, 1 tbsp triple sec, 1 1/2 oz lime juice, 1 tsp sugar, and 1 cup crushed ice on low for five seconds, then on high until firm. Pour into a champagne flute, garnish with a ch…",
+      "image": "https://drive.google.com/uc?export=view&id=1N4jGKOGOHhcGAR_4ur01aFxHpvW_RFt5",
+      "datePublished": "2025-09-29",
+      "prepTime": "6 minutes",
+      "recipeCategory": "Frozen Blended",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "1 1/2 oz Light rum",
+        "1 tblsp Triple sec",
+        "1 1/2 oz Lime juice",
+        "1 tsp Sugar",
+        "1 Cherry",
+        "1 cup crushed Ice"
+      ],
+      "recipeInstructions": "Blend 1 1/2 oz light rum, 1 tbsp triple sec, 1 1/2 oz lime juice, 1 tsp sugar, and 1 cup crushed ice on low for five seconds, then on high until firm. Pour into a champagne flute, garnish with a cherry, and serve.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Sour Family",
+        "Serve Frozen",
+        "Citrus",
+        "Moderate",
+        "Party",
+        "Light Refreshing",
+        "Season Tropical"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Frozen Daiquiri</h1>
+          <div class="info">Sep 29, 2025 · Medium · 6 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>1 1/2 oz Light rum</li><li>1 tblsp Triple sec</li><li>1 1/2 oz Lime juice</li><li>1 tsp Sugar</li><li>1 Cherry</li><li>1 cup crushed Ice</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Frozen Blended</div>
+                <div class="kv"><b>Glass</b> Flute</div>
+                <div class="kv"><b>Garnish</b> Lime Wheel + Cocktail Cherry</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Blend 1 1/2 oz light rum, 1 tbsp triple sec, 1 1/2 oz lime juice, 1 tsp sugar, and 1 cup crushed ice on low for five seconds, then on high until firm. Pour into a champagne flute, garnish with a cherry, and serve.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Sour Family</span><span class="pill">Serve Frozen</span><span class="pill">Citrus</span><span class="pill">Moderate</span><span class="pill">Party</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Season Tropical</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1N4jGKOGOHhcGAR_4ur01aFxHpvW_RFt5" data-alt="https://drive.google.com/thumbnail?id=1N4jGKOGOHhcGAR_4ur01aFxHpvW_RFt5&amp;sz=w1200" alt="Frozen Daiquiri" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/frozen-mint-daiquiri/index.html
+++ b/dist/frozen-mint-daiquiri/index.html
@@ -1,0 +1,1921 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Frozen Mint Daiquiri · Elixiary</title>
+  <meta name="description" content="Blend 2 oz light rum, 1 tbsp lime juice, 6 mint leaves, and 1 tsp sugar with 1 cup of crushed ice until smooth. Pour into an old-fashioned glass and serve.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/frozen-mint-daiquiri">
+  <meta property="og:title" content="Frozen Mint Daiquiri · Elixiary">
+  <meta property="og:description" content="Blend 2 oz light rum, 1 tbsp lime juice, 6 mint leaves, and 1 tsp sugar with 1 cup of crushed ice until smooth. Pour into an old-fashioned glass and serve.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1bJOtU1onqd4gMQbXkP5ASKpb4_iVfdG9">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/frozen-mint-daiquiri">
+  <meta name="twitter:title" content="Frozen Mint Daiquiri · Elixiary">
+  <meta name="twitter:description" content="Blend 2 oz light rum, 1 tbsp lime juice, 6 mint leaves, and 1 tsp sugar with 1 cup of crushed ice until smooth. Pour into an old-fashioned glass and serve.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1bJOtU1onqd4gMQbXkP5ASKpb4_iVfdG9">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/frozen-mint-daiquiri">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/frozen-mint-daiquiri",
+      "url": "https://www.elixiary.com/frozen-mint-daiquiri",
+      "name": "Frozen Mint Daiquiri",
+      "description": "Blend 2 oz light rum, 1 tbsp lime juice, 6 mint leaves, and 1 tsp sugar with 1 cup of crushed ice until smooth. Pour into an old-fashioned glass and serve.",
+      "image": "https://drive.google.com/uc?export=view&id=1bJOtU1onqd4gMQbXkP5ASKpb4_iVfdG9",
+      "datePublished": "2025-09-29",
+      "prepTime": "6 minutes",
+      "recipeCategory": "Frozen Blended",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "2 oz Light rum",
+        "1 tblsp Lime juice",
+        "6 Mint",
+        "1 tsp Sugar"
+      ],
+      "recipeInstructions": "Blend 2 oz light rum, 1 tbsp lime juice, 6 mint leaves, and 1 tsp sugar with 1 cup of crushed ice until smooth. Pour into an old-fashioned glass and serve.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Sour Family",
+        "Serve Frozen",
+        "Citrus",
+        "Fruity",
+        "Party",
+        "Light Refreshing",
+        "Season Tropical"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Frozen Mint Daiquiri</h1>
+          <div class="info">Sep 29, 2025 · Medium · 6 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>2 oz Light rum</li><li>1 tblsp Lime juice</li><li>6 Mint</li><li>1 tsp Sugar</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Frozen Blended</div>
+                <div class="kv"><b>Glass</b> Rocks</div>
+                <div class="kv"><b>Garnish</b> Mint Sprig</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Blend 2 oz light rum, 1 tbsp lime juice, 6 mint leaves, and 1 tsp sugar with 1 cup of crushed ice until smooth. Pour into an old-fashioned glass and serve.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Sour Family</span><span class="pill">Serve Frozen</span><span class="pill">Citrus</span><span class="pill">Fruity</span><span class="pill">Party</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Season Tropical</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1bJOtU1onqd4gMQbXkP5ASKpb4_iVfdG9" data-alt="https://drive.google.com/thumbnail?id=1bJOtU1onqd4gMQbXkP5ASKpb4_iVfdG9&amp;sz=w1200" alt="Frozen Mint Daiquiri" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/frozen-pineapple-daiquiri/index.html
+++ b/dist/frozen-pineapple-daiquiri/index.html
@@ -1,0 +1,1921 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Frozen Pineapple Daiquiri · Elixiary</title>
+  <meta name="description" content="Blend 1 1/2 oz light rum, 4 chunks of pineapple, 1 tbsp lime juice, and 1/2 tsp sugar with 1 cup of crushed ice until smooth. Pour into a cocktail glass and serve.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/frozen-pineapple-daiquiri">
+  <meta property="og:title" content="Frozen Pineapple Daiquiri · Elixiary">
+  <meta property="og:description" content="Blend 1 1/2 oz light rum, 4 chunks of pineapple, 1 tbsp lime juice, and 1/2 tsp sugar with 1 cup of crushed ice until smooth. Pour into a cocktail glass and serve.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=14ZTD3kgvk3B0oY4CErMW1xW6KMEaiiAm">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/frozen-pineapple-daiquiri">
+  <meta name="twitter:title" content="Frozen Pineapple Daiquiri · Elixiary">
+  <meta name="twitter:description" content="Blend 1 1/2 oz light rum, 4 chunks of pineapple, 1 tbsp lime juice, and 1/2 tsp sugar with 1 cup of crushed ice until smooth. Pour into a cocktail glass and serve.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=14ZTD3kgvk3B0oY4CErMW1xW6KMEaiiAm">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/frozen-pineapple-daiquiri">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/frozen-pineapple-daiquiri",
+      "url": "https://www.elixiary.com/frozen-pineapple-daiquiri",
+      "name": "Frozen Pineapple Daiquiri",
+      "description": "Blend 1 1/2 oz light rum, 4 chunks of pineapple, 1 tbsp lime juice, and 1/2 tsp sugar with 1 cup of crushed ice until smooth. Pour into a cocktail glass and serve.",
+      "image": "https://drive.google.com/uc?export=view&id=14ZTD3kgvk3B0oY4CErMW1xW6KMEaiiAm",
+      "datePublished": "2025-09-29",
+      "prepTime": "6 minutes",
+      "recipeCategory": "Frozen Blended",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "1 1/2 oz Light rum",
+        "4 chunks Pineapple",
+        "1 tblsp Lime juice",
+        "1/2 tsp Sugar"
+      ],
+      "recipeInstructions": "Blend 1 1/2 oz light rum, 4 chunks of pineapple, 1 tbsp lime juice, and 1/2 tsp sugar with 1 cup of crushed ice until smooth. Pour into a cocktail glass and serve.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Sour Family",
+        "Serve Frozen",
+        "Fruity",
+        "Moderate",
+        "Season Summer",
+        "Season Tropical",
+        "Party High Energy"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Frozen Pineapple Daiquiri</h1>
+          <div class="info">Sep 29, 2025 · Medium · 6 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>1 1/2 oz Light rum</li><li>4 chunks Pineapple</li><li>1 tblsp Lime juice</li><li>1/2 tsp Sugar</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Frozen Blended</div>
+                <div class="kv"><b>Glass</b> Martini</div>
+                <div class="kv"><b>Garnish</b> Pineapple Wedge</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Blend 1 1/2 oz light rum, 4 chunks of pineapple, 1 tbsp lime juice, and 1/2 tsp sugar with 1 cup of crushed ice until smooth. Pour into a cocktail glass and serve.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Sour Family</span><span class="pill">Serve Frozen</span><span class="pill">Fruity</span><span class="pill">Moderate</span><span class="pill">Season Summer</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Season Tropical</span><span class="pill">Party High Energy</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=14ZTD3kgvk3B0oY4CErMW1xW6KMEaiiAm" data-alt="https://drive.google.com/thumbnail?id=14ZTD3kgvk3B0oY4CErMW1xW6KMEaiiAm&amp;sz=w1200" alt="Frozen Pineapple Daiquiri" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/fruit-cooler/index.html
+++ b/dist/fruit-cooler/index.html
@@ -1,0 +1,1924 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Fruit Cooler · Elixiary</title>
+  <meta name="description" content="Toss strawberries with sugar and refrigerate overnight. Juice the lemon, reserving two slices, then mix the lemon juice, strawberries, apple juice, and soda water. In a highball glass filled with i…">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/fruit-cooler">
+  <meta property="og:title" content="Fruit Cooler · Elixiary">
+  <meta property="og:description" content="Toss strawberries with sugar and refrigerate overnight. Juice the lemon, reserving two slices, then mix the lemon juice, strawberries, apple juice, and soda water. In a highball glass filled with i…">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1XYGWvdOtIoE9CDmlt1ec9gA5Lo-Idiwb">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/fruit-cooler">
+  <meta name="twitter:title" content="Fruit Cooler · Elixiary">
+  <meta name="twitter:description" content="Toss strawberries with sugar and refrigerate overnight. Juice the lemon, reserving two slices, then mix the lemon juice, strawberries, apple juice, and soda water. In a highball glass filled with i…">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1XYGWvdOtIoE9CDmlt1ec9gA5Lo-Idiwb">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/fruit-cooler">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/fruit-cooler",
+      "url": "https://www.elixiary.com/fruit-cooler",
+      "name": "Fruit Cooler",
+      "description": "Toss strawberries with sugar and refrigerate overnight. Juice the lemon, reserving two slices, then mix the lemon juice, strawberries, apple juice, and soda water. In a highball glass filled with i…",
+      "image": "https://drive.google.com/uc?export=view&id=1XYGWvdOtIoE9CDmlt1ec9gA5Lo-Idiwb",
+      "datePublished": "2025-09-29",
+      "prepTime": "2 minutes",
+      "recipeCategory": "Unknown Other",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "1 can frozen Apple juice",
+        "1 cup Strawberries",
+        "2 tblsp Sugar",
+        "1 Lemon",
+        "1 Apple",
+        "1 L Soda water",
+        "Ice"
+      ],
+      "recipeInstructions": "Toss strawberries with sugar and refrigerate overnight. Juice the lemon, reserving two slices, then mix the lemon juice, strawberries, apple juice, and soda water. In a highball glass filled with ice and a slice of apple, pour the mixture and add the lemon slices.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "New Era",
+        "Fruity",
+        "Citrus",
+        "Serve Long",
+        "Brunch",
+        "Light Refreshing",
+        "Time Aperitif"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Fruit Cooler</h1>
+          <div class="info">Sep 29, 2025 · Easy · 2 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>1 can frozen Apple juice</li><li>1 cup Strawberries</li><li>2 tblsp Sugar</li><li>1 Lemon</li><li>1 Apple</li><li>1 L Soda water</li><li>Ice</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Unknown Other</div>
+                <div class="kv"><b>Glass</b> Highball</div>
+                <div class="kv"><b>Garnish</b> Lemon Wedge</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Toss strawberries with sugar and refrigerate overnight. Juice the lemon, reserving two slices, then mix the lemon juice, strawberries, apple juice, and soda water. In a highball glass filled with ice and a slice of apple, pour the mixture and add the lemon slices.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">New Era</span><span class="pill">Fruity</span><span class="pill">Citrus</span><span class="pill">Serve Long</span><span class="pill">Brunch</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Time Aperitif</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1XYGWvdOtIoE9CDmlt1ec9gA5Lo-Idiwb" data-alt="https://drive.google.com/thumbnail?id=1XYGWvdOtIoE9CDmlt1ec9gA5Lo-Idiwb&amp;sz=w1200" alt="Fruit Cooler" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/fruit-flip-flop/index.html
+++ b/dist/fruit-flip-flop/index.html
@@ -1,0 +1,1918 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Fruit Flip-Flop · Elixiary</title>
+  <meta name="description" content="Blend 1 cup of yoghurt with 1 cup of fruit juice until smooth, then pour into one tall glass, two medium glasses, or three small glasses.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/fruit-flip-flop">
+  <meta property="og:title" content="Fruit Flip-Flop · Elixiary">
+  <meta property="og:description" content="Blend 1 cup of yoghurt with 1 cup of fruit juice until smooth, then pour into one tall glass, two medium glasses, or three small glasses.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=1DqnB-96Jw2-9MpHowkCaVu-HBbWcmaaz">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/fruit-flip-flop">
+  <meta name="twitter:title" content="Fruit Flip-Flop · Elixiary">
+  <meta name="twitter:description" content="Blend 1 cup of yoghurt with 1 cup of fruit juice until smooth, then pour into one tall glass, two medium glasses, or three small glasses.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=1DqnB-96Jw2-9MpHowkCaVu-HBbWcmaaz">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/fruit-flip-flop">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/fruit-flip-flop",
+      "url": "https://www.elixiary.com/fruit-flip-flop",
+      "name": "Fruit Flip-Flop",
+      "description": "Blend 1 cup of yoghurt with 1 cup of fruit juice until smooth, then pour into one tall glass, two medium glasses, or three small glasses.",
+      "image": "https://drive.google.com/uc?export=view&id=1DqnB-96Jw2-9MpHowkCaVu-HBbWcmaaz",
+      "datePublished": "2025-09-29",
+      "prepTime": "2 minutes",
+      "recipeCategory": "Unknown Other",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "1 cup Yoghurt",
+        "1 cup Fruit juice"
+      ],
+      "recipeInstructions": "Blend 1 cup of yoghurt with 1 cup of fruit juice until smooth, then pour into one tall glass, two medium glasses, or three small glasses.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Contemporary Classic",
+        "Diet Dairy",
+        "Texture Creamy",
+        "Brunch",
+        "Light Refreshing",
+        "Time Brunchy"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Fruit Flip-Flop</h1>
+          <div class="info">Sep 29, 2025 · Easy · 2 minutes</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>1 cup Yoghurt</li><li>1 cup Fruit juice</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Unknown Other</div>
+                <div class="kv"><b>Glass</b> Highball</div>
+                <div class="kv"><b>Garnish</b> None</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Blend 1 cup of yoghurt with 1 cup of fruit juice until smooth, then pour into one tall glass, two medium glasses, or three small glasses.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Contemporary Classic</span><span class="pill">Diet Dairy</span><span class="pill">Texture Creamy</span><span class="pill">Brunch</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Time Brunchy</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=1DqnB-96Jw2-9MpHowkCaVu-HBbWcmaaz" data-alt="https://drive.google.com/thumbnail?id=1DqnB-96Jw2-9MpHowkCaVu-HBbWcmaaz&amp;sz=w1200" alt="Fruit Flip-Flop" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/dist/fruit-shake/index.html
+++ b/dist/fruit-shake/index.html
@@ -1,0 +1,1922 @@
+<!DOCTYPE html><html lang="en"><head>
+  <meta charset="utf-8">
+  
+  <!-- Debug toggles -->
+  <script type="module" src="/assets/debug.js"></script>
+
+  <!-- SEO & Meta Tags -->
+  <title>Fruit Shake · Elixiary</title>
+  <meta name="description" content="Blend 1 cup of yoghurt, 1 banana, 4 oz of frozen orange juice, 1/2 piece of textural fruit, and 6 ice cubes until smooth. Pour into a highball glass.">
+  <meta name="keywords" content="cocktails, recipes, drinks, mixology, bartending, ingredients, alcohol, beverages">
+  <meta name="author" content="Elixiary">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://www.elixiary.com/fruit-shake">
+  <meta property="og:title" content="Fruit Shake · Elixiary">
+  <meta property="og:description" content="Blend 1 cup of yoghurt, 1 banana, 4 oz of frozen orange juice, 1/2 piece of textural fruit, and 6 ice cubes until smooth. Pour into a highball glass.">
+  <meta property="og:image" content="https://drive.google.com/uc?export=view&amp;id=14U6YwT69XKerDzUuoUW-KWVCsYuLUCzR">
+  <meta property="og:site_name" content="Elixiary">
+  
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://www.elixiary.com/fruit-shake">
+  <meta name="twitter:title" content="Fruit Shake · Elixiary">
+  <meta name="twitter:description" content="Blend 1 cup of yoghurt, 1 banana, 4 oz of frozen orange juice, 1/2 piece of textural fruit, and 6 ice cubes until smooth. Pour into a highball glass.">
+  <meta name="twitter:image" content="https://drive.google.com/uc?export=view&amp;id=14U6YwT69XKerDzUuoUW-KWVCsYuLUCzR">
+  
+  <!-- PWA & Icons -->
+  <link rel="manifest" href="/manifest.json">
+  <link rel="icon" type="image/png" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="apple-touch-icon" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w180-h180-c-rw">
+  <link rel="icon" sizes="16x16" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w16-h16-c-rw">
+  <link rel="icon" sizes="32x32" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w32-h32-c-rw">
+  <link rel="icon" sizes="192x192" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w192-h192-c-rw">
+  <link rel="icon" sizes="512x512" href="https://lh3.googleusercontent.com/d/1MG6y6fHcYVunEEP4cFRlRpl3-CwExmPs=w512-h512-c-rw">
+  <meta name="theme-color" content="#111827">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Elixiary">
+  
+<!-- Security -->
+  <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      font-src 'self' https://fonts.gstatic.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      img-src 'self' data: https:;
+      connect-src 'self'
+        https://api.elixiary.com
+        https://www.google-analytics.com
+        https://region1.google-analytics.com
+        https://stats.g.doubleclick.net
+        https://www.googletagmanager.com;
+      script-src 'self' https://www.googletagmanager.com;
+    ">
+
+<link rel="preconnect" href="https://www.googletagmanager.com">
+<link rel="preconnect" href="https://www.google-analytics.com">
+  
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://www.elixiary.com/fruit-shake">
+  
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+  <link rel="dns-prefetch" href="https://api.elixiary.com">
+  
+  <!-- Modern fonts with display swap -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap" rel="stylesheet">
+  
+  <!-- Structured Data -->
+    <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://www.elixiary.com/#org",
+      "name": "Elixiary",
+      "url": "https://www.elixiary.com/",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.elixiary.com/og-image.jpg"
+      },
+      "sameAs": [
+        "https://instagram.com/elixiary.ai",
+        "https://tiktok.com/@elixiary.ai"
+      ]
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.elixiary.com/#website",
+      "url": "https://www.elixiary.com/",
+      "name": "Elixiary",
+      "description": "Discover and explore an extensive collection of cocktail recipes",
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "publisher": {
+        "@id": "https://www.elixiary.com/#org"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.elixiary.com/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "Recipe",
+      "@id": "https://www.elixiary.com/fruit-shake",
+      "url": "https://www.elixiary.com/fruit-shake",
+      "name": "Fruit Shake",
+      "description": "Blend 1 cup of yoghurt, 1 banana, 4 oz of frozen orange juice, 1/2 piece of textural fruit, and 6 ice cubes until smooth. Pour into a highball glass.",
+      "image": "https://drive.google.com/uc?export=view&id=14U6YwT69XKerDzUuoUW-KWVCsYuLUCzR",
+      "datePublished": "2025-09-29",
+      "prepTime": "1 minute",
+      "recipeCategory": "Unknown Other",
+      "recipeCuisine": "Cocktail",
+      "recipeIngredient": [
+        "1 cup fruit Yoghurt",
+        "1 Banana",
+        "4 oz frozen Orange juice",
+        "1/2 piece textural Fruit",
+        "6 Ice"
+      ],
+      "recipeInstructions": "Blend 1 cup of yoghurt, 1 banana, 4 oz of frozen orange juice, 1/2 piece of textural fruit, and 6 ice cubes until smooth. Pour into a highball glass.",
+      "author": {
+        "@type": "Organization",
+        "@id": "https://www.elixiary.com/#org",
+        "name": "Elixiary"
+      },
+      "keywords": [
+        "Contemporary Classic",
+        "Fruity",
+        "Texture Creamy",
+        "Serve Frozen",
+        "Brunch",
+        "Light Refreshing",
+        "Time Brunchy"
+      ]
+    }
+  ]
+}</script>
+
+  <style>
+    :root{
+      /* Light theme colors */
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --error: #DC2626;
+      --success: #059669;
+      --warning: #D97706;
+      
+      /* Dark theme colors */
+      --bg-dark: #0B0F19;
+      --text-dark: #F9FAFB;
+      --muted-dark: #9CA3AF;
+      --line-dark: #374151;
+      --line-2-dark: #1F2937;
+      --soft-dark: #111827;
+      --accent-dark: #F3F4F6;
+      
+      /* Design tokens */
+      --radius: 14px;
+      --radius-sm: 10px;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --shadow-dark: 0 14px 38px rgba(0,0,0,.3);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+      --ring-dark: 0 0 0 4px rgba(249,250,251,.08);
+      --fade: 160ms ease;
+
+      /* Responsive image sizes */
+      --thumbW: 160px;
+      --thumbH: 220px;
+      --detailW: 380px;
+      --detailMinH: 520px;
+    }
+    
+    /* Dark mode support */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: var(--bg-dark);
+        --text: var(--text-dark);
+        --muted: var(--muted-dark);
+        --line: var(--line-dark);
+        --line-2: var(--line-2-dark);
+        --soft: var(--soft-dark);
+        --accent: var(--accent-dark);
+        --shadow: var(--shadow-dark);
+        --ring: var(--ring-dark);
+      }
+    }
+    
+    /* Force light/dark theme classes */
+    [data-theme="light"] {
+      --bg: #fff;
+      --text: #0B0F19;
+      --muted: #6B7280;
+      --line: #E5E7EB;
+      --line-2: #EEF1F4;
+      --soft: #F7F8FA;
+      --accent: #111827;
+      --shadow: 0 14px 38px rgba(16,24,40,.06);
+      --ring: 0 0 0 4px rgba(17,24,39,.08);
+    }
+    
+    [data-theme="dark"] {
+      --bg: var(--bg-dark);
+      --text: var(--text-dark);
+      --muted: var(--muted-dark);
+      --line: var(--line-dark);
+      --line-2: var(--line-2-dark);
+      --soft: var(--soft-dark);
+      --accent: var(--accent-dark);
+      --shadow: var(--shadow-dark);
+      --ring: var(--ring-dark);
+    }
+    
+    @media (min-width:640px){
+      :root{ --thumbW:180px; --thumbH:240px; --detailW:420px; --detailMinH:560px; }
+    }
+    @media (min-width:1024px){
+      :root{ --thumbW:200px; --thumbH:260px; --detailW:460px; --detailMinH:600px; }
+    }
+
+    /* Base styles */
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    
+    body{
+      margin:0; 
+      padding-top: 64px;
+      font-family:"Plus Jakarta Sans","Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial;
+      color:var(--text); 
+      background:var(--bg); 
+      line-height:1.55; 
+      letter-spacing:.01em;
+      -webkit-font-smoothing:antialiased; 
+      -moz-osx-font-smoothing:grayscale;
+      transition: background-color var(--fade), color var(--fade);
+      min-height:100vh;
+      overflow-x:hidden;
+    }
+    a{color:inherit; text-decoration:none}
+
+    .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 6px;
+      background: var(--accent);
+      color: var(--bg);
+      padding: 8px;
+      text-decoration: none;
+      border-radius: 4px;
+      z-index: 1000;
+      font-size: 14px;
+    }
+    .skip-link:focus {
+      top: 6px;
+    }
+
+    /* Header */
+    header{ 
+      position: fixed !important;
+      top: 0 !important;
+      left: 0 !important;
+      right: 0 !important;
+      z-index: 9999 !important;
+      background: var(--bg); 
+      border-bottom: 1px solid var(--line-2);
+      backdrop-filter: saturate(120%) blur(6px); 
+      transition: box-shadow var(--fade), border-color var(--fade), background-color var(--fade);
+      display: block !important;
+      visibility: visible !important;
+      opacity: 1 !important;
+      transform: none !important;
+      width: 100% !important;
+    }
+    header.is-scrolled{
+      box-shadow: var(--shadow); 
+      border-color: transparent;
+      transition: all 0.3s ease;
+    }
+    .container{max-width:1120px; margin:0 auto; padding:0 20px}
+    .nav{height:64px; display:flex; align-items:center; gap:14px; justify-content:space-between}
+    .nav-controls{flex:1; display:flex; align-items:center; gap:16px; justify-content:flex-end;}
+    .nav-controls .search-wrap{flex:1;}
+    .theme-control{display:flex; align-items:center; gap:8px; background:transparent; flex:0 0 auto;}
+    .theme-control label{font-size:14px; font-weight:600; color:var(--muted);}
+    .theme-control select{
+      appearance:none;
+      background:var(--soft);
+      color:var(--text);
+      border:1px solid var(--line);
+      border-radius:var(--radius-sm);
+      padding:8px 12px;
+      font-size:14px;
+      font-weight:600;
+      cursor:pointer;
+      transition:background var(--fade), color var(--fade), border-color var(--fade), box-shadow var(--fade);
+    }
+    .theme-control select:focus{
+      outline:none;
+      border-color:var(--accent);
+      box-shadow:var(--ring);
+    }
+    [data-theme="dark"] .theme-control select{
+      background:var(--soft-dark);
+      color:var(--text-dark);
+      border-color:var(--line-dark);
+    }
+    [data-theme="dark"] .theme-control select:focus{
+      box-shadow:var(--ring-dark);
+    }
+    .brand{font-weight:700; letter-spacing:.01em; display:flex; align-items:center; gap:10px}
+    .home-icon{
+      color: var(--accent);
+      transition: all var(--fade);
+      flex-shrink: 0;
+    }
+    .brand:hover .home-icon{
+      transform: scale(1.05);
+      color: var(--text);
+    }
+
+    .brand-content {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      line-height: 1.2;
+    }
+
+    .brand-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--text);
+      transition: color var(--fade);
+    }
+
+    .brand-subtitle {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--muted);
+      margin-bottom: -2px;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      transition: color var(--fade);
+    }
+
+    .brand:hover .brand-name {
+      color: var(--accent);
+    }
+
+    .brand:hover .brand-subtitle {
+      color: var(--accent);
+      opacity: 0.8;
+    }
+
+    /* Mobile navbar optimization */
+    @media (max-width: 768px) {
+      .nav {
+        height: 60px;
+        gap: 12px;
+        padding: 0 16px;
+      }
+      
+      .brand {
+        min-width: 0;
+        flex-shrink: 0;
+        max-width: 140px;
+      }
+      
+      .brand-content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        line-height: 1.1;
+        min-width: 0;
+      }
+      
+      .brand-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+      
+      .brand-subtitle {
+        display: none; /* Hide subtitle on mobile */
+      }
+      
+      .nav-controls { gap: 12px; }
+      .search-wrap {
+        flex: 1;
+        min-width: 0;
+        max-width: calc(100% - 160px - 12px);
+      }
+      .theme-control label {
+        display: none;
+      }
+      .theme-control select {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      
+      .search {
+        width: 100%;
+        max-width: none;
+        padding: 8px 12px !important;
+        height: 40px !important;
+      }
+      
+      .search input {
+        font-size: 14px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 14px !important;
+      }
+      
+      .search svg {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .nav {
+        height: 56px;
+        gap: 8px;
+        padding: 0 12px;
+      }
+
+      .nav-controls {
+        gap: 8px;
+      }
+
+      .brand {
+        max-width: 120px;
+      }
+
+      .brand-name {
+        font-size: 1.2rem;
+      }
+
+      .theme-control select {
+        padding: 4px 8px;
+        font-size: 12px;
+      }
+
+      .home-icon {
+        width: 18px;
+        height: 18px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 8px);
+      }
+      
+      .search {
+        padding: 6px 10px !important;
+        height: 36px !important;
+      }
+
+      .clear {
+        padding: 0 8px !important;
+        font-size: 11px !important;
+        height: 100% !important;
+      }
+
+      .search input {
+        font-size: 13px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 13px !important;
+      }
+      
+      .search svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      .nav {
+        height: 52px;
+        gap: 6px;
+        padding: 0 8px;
+      }
+
+      .nav-controls {
+        gap: 6px;
+      }
+
+      .brand {
+        max-width: 100px;
+      }
+
+      .brand-name {
+        font-size: 1.1rem;
+      }
+
+      .home-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      .search-wrap {
+        max-width: calc(100% - 120px - 6px);
+      }
+
+      .search {
+        padding: 4px 8px !important;
+        height: 32px !important;
+      }
+
+      .theme-control select {
+        padding: 3px 6px;
+        font-size: 11px;
+      }
+
+      .search input {
+        font-size: 12px !important;
+        padding: 0 !important;
+        height: auto !important;
+      }
+      
+      .search input::placeholder {
+        font-size: 12px !important;
+      }
+      
+      .search svg {
+        width: 12px;
+        height: 12px;
+      }
+    }
+
+
+    @media (max-width: 768px) {
+      body {
+        padding-top: 60px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: 56px;
+      }
+    }
+
+    @media (max-width: 360px) {
+      body {
+        padding-top: 52px;
+      }
+    }
+
+    /* Search */
+    .search-wrap{display:flex; align-items:center; gap:10px}
+    .search{
+      display:flex; 
+      align-items:center; 
+      gap:10px; 
+      width:min(520px,64vw);
+      background:var(--bg); 
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      padding:10px 14px;
+      transition:border-color var(--fade), box-shadow var(--fade), background-color var(--fade);
+      box-shadow:0 2px 10px rgba(15,23,42,.03);
+    }
+    .search:focus-within{border-color:var(--muted); box-shadow:var(--ring)}
+    .search svg{flex:0 0 18px; color:var(--muted)}
+    .search input{
+      border:0;
+      outline:0;
+      background:transparent;
+      width:100%;
+      font-size:14px;
+      color:var(--text);
+      font-size: 16px; /* Prevent zoom on iOS */
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    input[type="search"]::-webkit-search-cancel-button,
+    input[type="search"]::-webkit-search-decoration {
+      appearance: none;
+      -webkit-appearance: none;
+      display: none;
+    }
+    .search input::placeholder {
+      color: var(--muted);
+      font-family: "Plus Jakarta Sans", "Inter", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      font-weight: 400;
+    }
+    .clear{
+      display:none;
+      align-items:center;
+      justify-content:center;
+      border:1px solid var(--line);
+      border-radius:999px;
+      padding:0 10px;
+      font-size:12px;
+      color:var(--muted);
+      background:var(--bg);
+      cursor:pointer;
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      height:100%;
+      min-height:0;
+    }
+    .clear:hover{transform:translateY(-1px); box-shadow:0 6px 14px rgba(16,24,40,.08)}
+    .clear:focus{outline:none; box-shadow:var(--ring)}
+    .clear.show{display:inline-flex}
+
+    /* Main spacing */
+    main{padding:28px 0; min-height:calc(100vh - 200px)}
+    .stack{display:flex; flex-direction:column; gap:22px}
+
+    /* Filters - Responsive Collapsible */
+    .filters {
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 32px;
+      box-shadow: 0 18px 40px rgba(15,23,42,.05);
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: border-color var(--fade), box-shadow var(--fade), transform var(--fade);
+    }
+
+    .filters:focus-within {
+      border-color: var(--accent);
+      box-shadow: 0 22px 48px rgba(15,23,42,.08);
+    }
+
+    .filters::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: linear-gradient(90deg, transparent, var(--accent), transparent);
+      opacity: 0.35;
+    }
+
+    .filters-header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-title {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filters-eyebrow {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .filters-heading {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: var(--text);
+    }
+
+    .filters-actions {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .results-count {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--muted);
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 6px 12px;
+    }
+
+    .results-number {
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    .filters-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      padding: 8px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform var(--fade), box-shadow var(--fade), border-color var(--fade), color var(--fade);
+      box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    .filters-toggle:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 26px rgba(15,23,42,.12);
+      color: var(--accent);
+    }
+
+    .filters-toggle:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    .filters-toggle.has-active {
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 12px 32px rgba(17,24,39,.18);
+    }
+
+    .filters-toggle__count {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      min-width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      background: var(--accent);
+      color: var(--bg);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 0 8px;
+    }
+
+    .filters-toggle.has-active .filters-toggle__count,
+    .filters-toggle__count.is-visible {
+      display: inline-flex;
+    }
+
+    .filters-toggle__icon {
+      width: 14px;
+      height: 14px;
+      transition: transform var(--fade);
+    }
+
+    .filters[data-expanded="true"] .filters-toggle__icon {
+      transform: rotate(180deg);
+    }
+
+    .filters-body {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filters[data-expanded="false"] .filters-body {
+      display: none;
+    }
+
+    .filter-groups {
+      display: grid;
+      gap: 20px;
+      scrollbar-width: thin;
+    }
+
+    .filter-section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filter-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .active-filters {
+      display: none;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px 16px;
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--soft);
+    }
+
+    .active-filters.has-active {
+      display: flex;
+    }
+
+    .active-filters__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .active-filter-label {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .active-filter-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .active-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      background: var(--bg);
+      border: 1px solid var(--line);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 6px 12px;
+      cursor: pointer;
+      transition: all var(--fade);
+    }
+
+    .active-filter-chip:hover,
+    .active-filter-chip:focus {
+      outline: none;
+      border-color: var(--accent);
+      color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(17,24,39,.08);
+    }
+
+    .active-filter-chip span[aria-hidden="true"] {
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .active-filter-clear {
+      border: none;
+      background: transparent;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      cursor: pointer;
+      padding: 6px 8px;
+    }
+
+    .active-filter-clear:hover,
+    .active-filter-clear:focus {
+      text-decoration: underline;
+      outline: none;
+    }
+
+    .filter-chips {
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      padding: 4px 0 8px;
+      margin: 0;
+      scroll-snap-type: x proximity;
+      scrollbar-width: thin;
+    }
+
+    .filter-chips::after {
+      content: '';
+      flex: 0 0 12px;
+    }
+
+    .filter-chips[data-scrollable="true"] {
+      -webkit-overflow-scrolling: touch;
+    }
+
+    @media (max-width: 1023px) {
+      .filter-chips {
+        flex-wrap: wrap;
+        overflow-x: visible;
+        row-gap: 8px;
+      }
+
+      .filter-chips::after {
+        content: none;
+        display: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+      }
+    }
+
+    .filter-chips::-webkit-scrollbar,
+    .filters-body::-webkit-scrollbar,
+    .filter-groups::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    .filter-chips::-webkit-scrollbar-thumb,
+    .filters-body::-webkit-scrollbar-thumb,
+    .filter-groups::-webkit-scrollbar-thumb {
+      background: var(--line);
+      border-radius: 999px;
+    }
+
+    .filter-chips::-webkit-scrollbar-track,
+    .filters-body::-webkit-scrollbar-track,
+    .filter-groups::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .chip {
+      border: 1px solid var(--line);
+      background: var(--bg);
+      color: var(--text);
+      padding: 10px 16px;
+      border-radius: var(--radius-sm);
+      font-size: 13px;
+      font-weight: 500;
+      transition: all var(--fade);
+      cursor: pointer;
+      min-height: 42px;
+      display: flex;
+      align-items: center;
+      position: relative;
+      overflow: hidden;
+      scroll-snap-align: start;
+    }
+
+    .chip::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--accent);
+      opacity: 0;
+      transition: all var(--fade);
+      z-index: 0;
+      border-radius: inherit;
+    }
+
+    .chip span {
+      position: relative;
+      z-index: 1;
+    }
+
+    .chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(16,24,40,.08);
+      border-color: var(--accent);
+    }
+
+    .chip:focus {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(17,24,39,.1);
+    }
+
+    .chip.is-active,
+    .chip[aria-pressed="true"] {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--bg);
+      font-weight: 600;
+      box-shadow: 0 2px 8px rgba(17,24,39,.15);
+    }
+
+    .chip.is-active::before,
+    .chip[aria-pressed="true"]::before {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+      .filters {
+        padding: 24px 26px;
+        gap: 20px;
+      }
+
+      .filters-header {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .filters-title {
+        flex: 1;
+      }
+
+      .filters-actions {
+        justify-content: flex-end;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .filter-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .filters {
+        padding: 28px 32px;
+        gap: 24px;
+        max-height: min(65vh, 520px);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .filters-body {
+        gap: 28px;
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-section {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 24px;
+      }
+
+      .filter-label {
+        min-width: 140px;
+        margin-bottom: 0;
+      }
+
+      .filter-groups {
+        overflow-y: auto;
+        padding-right: 12px;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .filter-chips {
+        flex: 1;
+        flex-wrap: wrap;
+        overflow-x: visible;
+        padding-bottom: 0;
+        scroll-snap-type: none;
+        min-width: 0;
+      }
+
+      .filter-chips::after {
+        content: none;
+      }
+
+      .filter-chips[data-scrollable="true"] {
+        mask-image: none;
+        -webkit-mask-image: none;
+        max-height: 160px;
+        overflow-y: auto;
+        padding-right: 8px;
+      }
+    }
+    
+
+    .filters[style*="display: none"] {
+      display: none !important;
+      visibility: hidden !important;
+      height: 0 !important;
+      overflow: hidden !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    .grid{display:grid; grid-template-columns:1fr; gap:16px}
+    @media (min-width:1024px){ .grid{grid-template-columns:1fr 1fr} }
+
+    .card{
+      display:grid; 
+      grid-template-columns:1fr var(--thumbW); 
+      column-gap:18px; 
+      align-items:stretch;
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:var(--radius); 
+      overflow:hidden;
+      transition:transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease; 
+      will-change:transform;
+      text-decoration: none;
+    }
+    .card:hover{transform:translateY(-3px); box-shadow:var(--shadow); border-color:var(--line)}
+    .card:focus{outline:none; box-shadow:var(--ring)}
+    .card-body{
+      padding:18px 18px; 
+      display:flex; 
+      flex-direction:column; 
+      justify-content:center; 
+      min-height:var(--thumbH); 
+      gap:10px
+    }
+    .title{margin:0; font-weight:700; letter-spacing:.01em; font-size:18px}
+    .facts{display:flex; flex-direction:column; gap:4px}
+    .fact{font-size:13px; color:var(--muted)}
+    .fact .label{color:var(--muted); margin-right:8px; font-weight: 500}
+    .pills{display:flex; flex-wrap:wrap; gap:8px; margin-top:4px}
+    .pill{
+      font-size:11px; 
+      color:var(--muted); 
+      border:1px solid var(--line); 
+      padding:4px 8px; 
+      border-radius:999px; 
+      background:var(--soft)
+    }
+
+    .thumb-rail{
+      position:relative; 
+      width:var(--thumbW); 
+      height:var(--thumbH);
+      border-left:1px solid var(--line-2); 
+      background:var(--soft); 
+      overflow:hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .thumb{ 
+      width:100%; 
+      height:100%; 
+      object-fit:cover; /* Changed from contain to cover to fill container */
+      background:var(--soft);
+      transition:transform 500ms cubic-bezier(.2,.8,.2,1), opacity var(--fade), filter var(--fade); 
+      border-radius:0;
+    }
+    
+    .thumb.loading {
+      filter: blur(5px);
+      opacity: 0.7;
+    }
+    
+    .thumb.loaded {
+      filter: blur(0);
+      opacity: 1;
+    }
+    .card:hover .thumb{transform:scale(1.02)}
+
+    /* Enhanced Skeletons */
+    .skeleton{
+      position:relative; 
+      overflow:hidden; 
+      background:var(--soft);
+      border-radius:8px;
+      animation:pulse 1.5s ease-in-out infinite;
+    }
+    
+    .skeleton::after{
+      content:""; 
+      position:absolute; 
+      inset:0;
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.6) 25%, 
+        rgba(255,255,255,.8) 50%, 
+        rgba(255,255,255,.6) 75%, 
+        rgba(255,255,255,0) 100%);
+      transform:translateX(-100%); 
+      animation:shimmer 2s ease-in-out infinite;
+    }
+    
+    [data-theme="dark"] .skeleton {
+      background:var(--soft-dark);
+    }
+    
+    [data-theme="dark"] .skeleton::after {
+      background:linear-gradient(90deg, 
+        rgba(255,255,255,0) 0%, 
+        rgba(255,255,255,.1) 25%, 
+        rgba(255,255,255,.2) 50%, 
+        rgba(255,255,255,.1) 75%, 
+        rgba(255,255,255,0) 100%);
+    }
+    
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.8; }
+    }
+    
+    @keyframes shimmer {
+      0% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+      100% { transform: translateX(100%); }
+    }
+    
+    .skeleton-thumb{
+      width:100%; 
+      height:100%;
+      border-radius:12px;
+    }
+    
+    /* Skeleton card specific styles */
+    .skeleton-card {
+      animation: fadeInUp 0.6s ease-out;
+    }
+    
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(20px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .detail{ display:grid; gap:18px; grid-template-columns:1fr; }
+    @media (min-width:900px){ .detail{ grid-template-columns: 1fr var(--detailW); align-items:start; } }
+    .detail-rail{
+      border:1px solid var(--line-2);
+      border-radius:18px;
+      background:var(--soft);
+      padding:18px;
+      overflow:hidden;
+      box-shadow:var(--shadow);
+    }
+    .detail-rail:not(.skeleton){
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    .detail-rail.skeleton{
+      display:grid;
+      place-items:center;
+      min-height:var(--detailMinH);
+    }
+    .detail-img{
+      width:100%;
+      height:auto;
+      max-height:80vh;
+      object-fit:contain;
+      background:var(--soft);
+      display:block;
+    }
+    article{ 
+      background:var(--bg); 
+      border:1px solid var(--line-2); 
+      border-radius:18px; 
+      padding:26px; 
+      box-shadow:var(--shadow); 
+    }
+    article h1{margin:0 0 6px; font-size:clamp(28px,3.2vw,36px); letter-spacing:.01em}
+    .info{color:var(--muted); font-size:14px; margin-bottom:16px}
+    .row{display:flex; flex-wrap:wrap; gap:22px; margin:10px 0 8px}
+    .col{flex:1 1 280px}
+    .list{margin:10px 0 0; padding-left:18px}
+    .list li {
+      margin-bottom: 4px;
+    }
+    .kvs{display:grid; gap:8px}
+    .kv{display:flex; gap:6px; align-items:center; color:var(--muted); font-size:14px}
+    .kv b{font-weight:600; color:var(--text)}
+    .back{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 12px; 
+      margin-top:18px; 
+      border:1px solid var(--line);
+      border-radius:999px; 
+      color:var(--muted); 
+      background:var(--bg); 
+      transition:transform var(--fade), box-shadow var(--fade), border-color var(--fade);
+      text-decoration: none;
+    }
+    .back:hover{transform:translateY(-1px); box-shadow:0 10px 22px rgba(16,24,40,.08); border-color:var(--line)}
+    .back:focus{outline:none; box-shadow:var(--ring)}
+
+    /* Loading states */
+    .loading-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid var(--line);
+      border-top: 2px solid var(--accent);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    
+    .spinner-large {
+      width: 24px;
+      height: 24px;
+      border: 3px solid var(--line);
+      border-top: 3px solid var(--accent);
+    }
+    
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+    
+    .loading-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      border-radius: inherit;
+    }
+    
+    [data-theme="dark"] .loading-overlay {
+      background: rgba(17, 24, 39, 0.9);
+    }
+    
+    .loading-text {
+      margin-left: 8px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    /* Error states */
+    .error-state {
+      text-align: center;
+      padding: 40px 20px;
+    }
+    .error-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+      opacity: 0.5;
+    }
+    .retry-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      margin-top: 16px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--bg);
+      color: var(--text);
+      cursor: pointer;
+      transition: all var(--fade);
+      text-decoration: none;
+    }
+    .retry-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(16,24,40,.08);
+    }
+    .retry-btn:focus {
+      outline: none;
+      box-shadow: var(--ring);
+    }
+
+    /* Empty states */
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      color: var(--muted);
+    }
+    .empty-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+      opacity: 0.3;
+    }
+
+    /* Offline indicator */
+    .offline-indicator {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--warning);
+      color: white;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 500;
+      z-index: 1000;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateX(-50%) translateY(100px);
+      transition: all var(--fade);
+    }
+    .offline-indicator.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+
+    /* Footer */
+    footer{
+      border-top:1px solid var(--line-2); 
+      padding:24px 0; 
+      color:var(--muted); 
+      font-size:13px;
+      background: var(--soft);
+    }
+
+    /* Utilities */
+    .fade-in{animation:fade 180ms ease both}
+    @keyframes fade{from{opacity:0; transform:translateY(2px)} to{opacity:1; transform:none}}
+    .hide{display:none !important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    .center{display:flex; justify-content:center}
+    .err{
+      color:var(--error); 
+      background:rgba(220, 38, 38, 0.1); 
+      border:1px solid rgba(220, 38, 38, 0.2); 
+      padding:12px 14px; 
+      border-radius:12px;
+      margin: 20px 0;
+    }
+
+    .load-more{ 
+      display:inline-flex; 
+      align-items:center; 
+      gap:8px; 
+      padding:10px 14px; 
+      margin:8px auto 0;
+      border:1px solid var(--line); 
+      border-radius:999px; 
+      background:var(--bg); 
+      cursor:pointer;
+      transition:transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+      color: var(--text);
+      font-size: 14px;
+      min-height: 44px; /* Better touch target */
+    }
+    .load-more:hover{transform:translateY(-1px); box-shadow:0 8px 20px rgba(16,24,40,.08); border-color:var(--line)}
+    .load-more:focus{outline:none; box-shadow:var(--ring)}
+    .load-more:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      transform: none !important;
+    }
+    #sentinel{height:1px}
+
+    .live-region {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    /* Focus management */
+    .focus-trap {
+      outline: none;
+    }
+
+    /* High contrast mode support */
+    @media (prefers-contrast: high) {
+      :root {
+        --line: #000;
+        --line-2: #000;
+        --muted: #000;
+      }
+      [data-theme="dark"] {
+        --line: #fff;
+        --line-2: #fff;
+        --muted: #fff;
+      }
+    }
+
+    /* Reduced motion support */
+    @media (prefers-reduced-motion:reduce){
+      .card:hover .thumb{transform:none}
+      .fade-in{animation:none}
+      .search:focus-within{box-shadow:none}
+      .chip:hover{transform:none}
+      .clear:hover{transform:none}
+      .back:hover{transform:none}
+      .load-more:hover{transform:none}
+      .retry-btn:hover{transform:none}
+      .spinner{animation:none}
+      *{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* Footer */
+    .footer {
+      margin-top: 80px;
+      margin-bottom: 0;
+      padding: 0;
+    }
+    
+    .footer-cover {
+      position: relative;
+      height: 60vh;
+      min-height: 400px;
+      max-height: 600px;
+      overflow: hidden;
+    }
+
+    .cover-image-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .cover-img {
+      width: 100%;
+      height: 100%;
+      display: block;
+      object-fit: cover;
+      object-position: center;
+      filter: grayscale(100%) contrast(1.2);
+      transition: all 0.8s ease;
+    }
+    
+    .cover-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        135deg,
+        rgba(0,0,0,0.7) 0%,
+        rgba(0,0,0,0.5) 50%,
+        rgba(0,0,0,0.8) 100%
+      );
+      transition: all 0.8s ease;
+    }
+    
+    .cover-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: white;
+      z-index: 2;
+      max-width: 600px;
+      padding: 0 20px;
+    }
+    
+    .cover-title {
+      font-size: 48px;
+      font-weight: 700;
+      margin-bottom: 16px;
+      letter-spacing: 0.02em;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .cover-description {
+      font-size: 18px;
+      line-height: 1.6;
+      margin-bottom: 32px;
+      opacity: 0.9;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+    }
+    
+    .cover-social-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius-sm);
+      color: white;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: 500;
+      backdrop-filter: blur(10px);
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover {
+      background: rgba(255,255,255,0.2);
+      border-color: rgba(255,255,255,0.4);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0,0,0,0.3);
+    }
+    
+    .cover-social-link svg {
+      color: white;
+      transition: all var(--fade);
+    }
+    
+    .cover-social-link:hover svg {
+      transform: scale(1.1);
+    }
+    
+    .footer-bottom {
+      background: var(--bg);
+      border-top: 1px solid var(--line);
+      padding: 30px 0;
+    }
+    
+    .footer-bottom .container {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    @media (min-width: 768px) {
+      .footer-bottom .container {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+    }
+    
+    .footer-links {
+      display: flex;
+      gap: 24px;
+    }
+    
+    .footer-link {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--fade);
+    }
+    
+    .footer-link:hover {
+      color: var(--accent);
+      text-decoration: underline;
+    }
+    
+    .footer-copyright {
+      color: var(--muted);
+      font-size: 14px;
+      font-weight: 400;
+    }
+    
+    @media (max-width: 767px) {
+      .footer-cover {
+        height: 50vh;
+        min-height: 300px;
+      }
+      
+      .cover-title {
+        font-size: 36px;
+      }
+      
+      .cover-description {
+        font-size: 16px;
+      }
+      
+      .cover-social {
+        flex-direction: column;
+        gap: 12px;
+      }
+      
+      .cover-social-link {
+        justify-content: center;
+      }
+      
+      .footer-links {
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 16px;
+      }
+      
+      .footer-copyright {
+        text-align: center;
+      }
+    }
+
+    /* Print styles */
+    @media print {
+      header, footer, .load-more, .retry-btn {
+        display: none !important;
+      }
+      .card, article {
+        break-inside: avoid;
+        box-shadow: none;
+        border: 1px solid #000;
+      }
+      body {
+        background: white !important;
+        color: black !important;
+      }
+    }
+  </style>
+
+<!-- Google Analytics 4 + Consent Mode v2 -->
+<script type="module" src="/assets/analytics.js"></script>
+
+</head>
+
+<body data-theme="light">
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  
+  <div id="live-region" class="live-region" aria-live="polite" aria-atomic="true"></div>
+  
+  <div id="offline-indicator" class="offline-indicator">
+    📡 You're offline. Some features may not work.
+  </div>
+
+  <!-- Header -->
+  <header id="hdr" role="banner">
+    <div class="container">
+      <nav class="nav" role="navigation" aria-label="Main navigation">
+        <a href="/" class="brand" aria-label="Elixiary home" data-router-link="">
+          <svg class="home-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            <polyline points="9,22 9,12 15,12 15,22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></polyline>
+          </svg>
+          <div class="brand-content">
+            <span class="brand-name">Elixiary</span>
+            <span class="brand-subtitle">Craft Perfect Cocktails</span>
+          </div>
+        </a>
+        <div class="nav-controls">
+          <div class="search-wrap">
+            <div class="search" role="search">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M21 21l-4.3-4.3M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>
+              </svg>
+              <label for="q" class="sr-only">Search recipes</label>
+              <input id="q" type="search" placeholder="Search..." autocomplete="off" aria-label="Search recipes by name, tag, mood, or ingredient" aria-describedby="search-help">
+              <button id="clear" class="clear" type="button" aria-label="Clear search">
+                <span aria-hidden="true">✕</span>
+                <span class="sr-only">Clear</span>
+              </button>
+            </div>
+            <div id="search-help" class="sr-only">
+              Use this search to find cocktail recipes by name, ingredients, tags, or mood
+            </div>
+          </div>
+          <div class="theme-control" role="group" aria-label="Theme selection">
+            <label for="theme-select">Theme</label>
+            <select id="theme-select" aria-label="Theme preference">
+              <option value="auto">Auto</option>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Main -->
+  <main id="main-content" role="main">
+    <div class="container stack">
+      <!-- Filters -->
+      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
+        <div class="filters-header">
+          <div class="filters-title">
+            <span class="filters-eyebrow">Refine results</span>
+            <h2 id="filters-heading" class="filters-heading">Filters</h2>
+          </div>
+          <div class="filters-actions">
+            <div class="results-count" aria-live="polite">
+              <span class="results-number" id="count">0</span>
+              recipes found
+            </div>
+            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
+              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
+              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
+              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
+              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="filters-body" class="filters-body">
+          <div id="active-filters" class="active-filters" aria-live="polite"></div>
+          <div class="filter-groups">
+            <div class="filter-section">
+              <div class="filter-label" id="category-label">Category</div>
+              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
+            </div>
+            <div class="filter-section">
+              <div class="filter-label" id="mood-label">Mood</div>
+              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- List / Detail -->
+      <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">
+      <div class="detail fade-in">
+        <article>
+          <h1>Fruit Shake</h1>
+          <div class="info">Sep 29, 2025 · Easy · 1 minute</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list"><li>1 cup fruit Yoghurt</li><li>1 Banana</li><li>4 oz frozen Orange juice</li><li>1/2 piece textural Fruit</li><li>6 Ice</li></ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> Unknown Other</div>
+                <div class="kv"><b>Glass</b> Highball</div>
+                <div class="kv"><b>Garnish</b> None</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>Blend 1 cup of yoghurt, 1 banana, 4 oz of frozen orange juice, 1/2 piece of textural fruit, and 6 ice cubes until smooth. Pour into a highball glass.</div>
+          
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills"><span class="pill">Contemporary Classic</span><span class="pill">Fruity</span><span class="pill">Texture Creamy</span><span class="pill">Serve Frozen</span><span class="pill">Brunch</span></div>
+            
+          
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills"><span class="pill">Light Refreshing</span><span class="pill">Time Brunchy</span></div>
+            
+          <p>
+            <a class="back" href="/" role="button" data-router-link="">
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        
+        <div class="detail-rail skeleton">
+          <img class="detail-img" src="https://drive.google.com/uc?export=view&amp;id=14U6YwT69XKerDzUuoUW-KWVCsYuLUCzR" data-alt="https://drive.google.com/thumbnail?id=14U6YwT69XKerDzUuoUW-KWVCsYuLUCzR&amp;sz=w1200" alt="Fruit Shake" data-validate-image="">
+        </div>
+      
+      </div>
+  </div>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer role="contentinfo" class="footer">
+    <!-- Cover Photo Section -->
+    <div class="footer-cover">
+      <div class="cover-image-container">
+        <img src="https://lh3.googleusercontent.com/d/1hAttK6U0rbhGZZjAZx8nCqcZM3JX2BEs=w1920-h1080-c" alt="Elegant cocktail presentation" class="cover-img">
+        <div class="cover-overlay"></div>
+        <div class="cover-content">
+          <h2 class="cover-title">Elixiary</h2>
+          <p class="cover-description">Discover the art of mixology with our curated collection of premium cocktail recipes.</p>
+          <div class="cover-social">
+            <a href="https://instagram.com/elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on Instagram">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5" stroke="currentColor" stroke-width="1.5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" stroke="currentColor" stroke-width="1.5"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></line>
+              </svg>
+              <span>Instagram</span>
+            </a>
+            <a href="https://tiktok.com/@elixiary.ai" target="_blank" rel="noopener noreferrer" class="cover-social-link" aria-label="Follow us on TikTok">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <span>TikTok</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Footer Bottom -->
+    <div class="footer-bottom">
+      <div class="container">
+        <div class="footer-links">
+          <a href="/privacy" class="footer-link">Privacy</a>
+          <a href="/terms" class="footer-link">Terms</a>
+          <a href="/contact" class="footer-link">Contact</a>
+        </div>
+        <div class="footer-copyright">
+          © <span id="year"></span> Elixiary. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+<script type="module" src="/assets/app.js"></script>
+
+
+
+
+
+
+</body></html>

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,7 @@
       { "source": "/privacy", "destination": "/privacy.html" },
       { "source": "/terms",   "destination": "/terms.html" },
       { "source": "/contact", "destination": "/contact.html" },
+      { "source": "/:slug",   "destination": "/:slug/index.html" },
       { "source": "/**",      "destination": "/index.html" }
     ],
     "headers": [

--- a/scripts/prerender-home.js
+++ b/scripts/prerender-home.js
@@ -10,6 +10,7 @@ if (proxyUrl) {
 }
 
 const API_URL = 'https://api.elixiary.com/v1/list';
+const POST_API_URL = 'https://api.elixiary.com/v1/post';
 const OUTPUT_PATH = path.join(__dirname, '..', 'dist', 'index.html');
 const SITE_ORIGIN = 'https://www.elixiary.com';
 const USER_AGENT = 'ElixiaryBuildBot/1.0 (+https://www.elixiary.com)';
@@ -267,6 +268,392 @@ async function updateStructuredData($, recipes) {
   script.text(JSON.stringify(data, null, 2));
 }
 
+async function fetchRecipeDetail(slug) {
+  if (!slug) return null;
+  const target = `${POST_API_URL}/${encodeURIComponent(slug)}`;
+  const response = await fetch(target, {
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch recipe ${slug}: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!data?.ok || !data?.post) {
+    throw new Error(`Unexpected API response when fetching recipe ${slug}.`);
+  }
+
+  return data.post;
+}
+
+function buildRecipeDescription(recipe) {
+  if (!recipe) return '';
+
+  const fallback = recipe.name
+    ? `Learn how to make ${recipe.name} with detailed ingredients and instructions. Discover more cocktail recipes at Elixiary.`
+    : 'Discover and explore amazing cocktail recipes with detailed ingredients and instructions.';
+
+  const instructions = String(recipe.instructions || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (instructions) {
+    return instructions.length > 200 ? `${instructions.slice(0, 197)}…` : instructions;
+  }
+
+  const details = [];
+  if (recipe.category) {
+    details.push(labelize(recipe.category));
+  }
+  if (recipe.difficulty) {
+    details.push(`Difficulty: ${recipe.difficulty}`);
+  }
+  if (recipe.prep_time) {
+    details.push(`Prep: ${recipe.prep_time}`);
+  }
+
+  if (details.length) {
+    return `${recipe.name || 'This cocktail'} – ${details.join(' · ')}.`;
+  }
+
+  return fallback;
+}
+
+function buildRecipeDetailMarkup(recipe) {
+  const infoParts = [];
+  const formattedDate = formatDate(recipe.date);
+  if (formattedDate) {
+    infoParts.push(escapeHtml(formattedDate));
+  }
+  if (recipe.difficulty) {
+    infoParts.push(escapeHtml(recipe.difficulty));
+  }
+  if (recipe.prep_time) {
+    infoParts.push(escapeHtml(recipe.prep_time));
+  }
+
+  const infoLine = infoParts.length ? infoParts.join(' · ') : '';
+
+  const ingredientsList = Array.isArray(recipe.ingredients) && recipe.ingredients.length
+    ? recipe.ingredients
+        .map((ingredient) => {
+          const measure = String(ingredient.measure || '').trim();
+          const name = String(ingredient.name || '').trim();
+          const combined = [measure, name].filter(Boolean).join(' ');
+          return `<li>${escapeHtml(combined)}</li>`;
+        })
+        .join('')
+    : '<li>—</li>';
+
+  const tags = Array.isArray(recipe.tags) && recipe.tags.length
+    ? recipe.tags
+        .map((tag) => `<span class="pill">${escapeHtml(labelize(tag))}</span>`)
+        .join('')
+    : '';
+
+  const moods = Array.isArray(recipe.mood_labels) && recipe.mood_labels.length
+    ? recipe.mood_labels
+        .map((mood) => `<span class="pill">${escapeHtml(labelize(mood))}</span>`)
+        .join('')
+    : '';
+
+  const instructions = String(recipe.instructions || 'No instructions available.')
+    .split(/\r?\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => escapeHtml(line))
+    .join('<br>');
+
+  const rawImageUrl = recipe.image_url || recipe.image_thumb || '';
+  const fallbackImage = recipe.image_thumb || rawImageUrl || getPlaceholderImage(recipe);
+  const imageSection = rawImageUrl
+    ? `
+        <div class="detail-rail skeleton">
+          <img class="detail-img"
+               src="${escapeHtml(rawImageUrl)}"
+               data-alt="${escapeHtml(fallbackImage)}"
+               alt="${escapeHtml(recipe.name || '')}"
+               data-validate-image>
+        </div>
+      `
+    : `
+        <div class="detail-rail skeleton" aria-hidden="true"></div>
+      `;
+
+  return `
+      <div class="detail fade-in">
+        <article>
+          <h1>${escapeHtml(recipe.name || 'Untitled')}</h1>
+          <div class="info">${infoLine}</div>
+          <div class="row">
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Ingredients</h3>
+              <ul class="list">${ingredientsList}</ul>
+            </div>
+            <div class="col">
+              <h3 style="margin:0 0 6px;font-size:16px">Details</h3>
+              <div class="kvs">
+                <div class="kv"><b>Category</b> ${escapeHtml(labelize(recipe.category || '-'))}</div>
+                <div class="kv"><b>Glass</b> ${escapeHtml(labelize(recipe.glass || '-'))}</div>
+                <div class="kv"><b>Garnish</b> ${escapeHtml(labelize(recipe.garnish || '-'))}</div>
+              </div>
+            </div>
+          </div>
+          <h3 style="margin-top:16px;font-size:16px">Instructions</h3>
+          <div>${instructions || 'No instructions available.'}</div>
+          ${tags
+            ? `
+              <h3 style="margin-top:16px;font-size:16px">Tags</h3>
+              <div class="pills">${tags}</div>
+            `
+            : ''}
+          ${moods
+            ? `
+              <h3 style="margin-top:12px;font-size:16px">Mood</h3>
+              <div class="pills">${moods}</div>
+            `
+            : ''}
+          <p>
+            <a class="back" href="/" role="button" data-router-link>
+              <span aria-hidden="true">←</span> Back to all recipes
+            </a>
+          </p>
+        </article>
+        ${imageSection}
+      </div>
+  `;
+}
+
+function sanitizeRecipeNode(node) {
+  const clone = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (value === undefined || value === null || value === '') continue;
+    if (Array.isArray(value)) {
+      const filtered = value.filter((item) => item !== undefined && item !== null && item !== '');
+      if (!filtered.length) continue;
+      clone[key] = filtered;
+    } else if (typeof value === 'object' && !Array.isArray(value)) {
+      const nested = sanitizeRecipeNode(value);
+      if (Object.keys(nested).length) {
+        clone[key] = nested;
+      }
+    } else {
+      clone[key] = value;
+    }
+  }
+  return clone;
+}
+
+function buildRecipeStructuredData(baseData, recipe) {
+  let graph = [];
+  const baseGraph = Array.isArray(baseData?.['@graph']) ? baseData['@graph'] : [];
+  if (baseGraph.length) {
+    graph = baseGraph
+      .filter((node) => {
+        const type = Array.isArray(node?.['@type']) ? node['@type'][0] : node?.['@type'];
+        if (!type) return true;
+        const normalized = String(type).toLowerCase();
+        return normalized !== 'itemlist' && normalized !== 'recipe';
+      })
+      .map((node) => JSON.parse(JSON.stringify(node)));
+  }
+
+  const canonicalUrl = `${SITE_ORIGIN}/${encodeURIComponent(recipe.slug || '')}`;
+  const description = buildRecipeDescription(recipe);
+  const ingredients = Array.isArray(recipe.ingredients)
+    ? recipe.ingredients
+        .map((ingredient) => {
+          const measure = String(ingredient.measure || '').trim();
+          const name = String(ingredient.name || '').trim();
+          const combined = [measure, name].filter(Boolean).join(' ');
+          return combined.trim();
+        })
+        .filter(Boolean)
+    : [];
+
+  const keywordValues = [
+    ...(Array.isArray(recipe.tags) ? recipe.tags.map((tag) => labelize(tag)).filter(Boolean) : []),
+    ...(Array.isArray(recipe.mood_labels) ? recipe.mood_labels.map((mood) => labelize(mood)).filter(Boolean) : [])
+  ];
+
+  const dedupedKeywords = Array.from(new Set(keywordValues));
+
+  const recipeNode = sanitizeRecipeNode({
+    '@type': 'Recipe',
+    '@id': canonicalUrl,
+    url: canonicalUrl,
+    name: recipe.name,
+    description,
+    image: recipe.image_url || recipe.image_thumb,
+    datePublished: recipe.date,
+    prepTime: recipe.prep_time,
+    recipeCategory: recipe.category ? labelize(recipe.category) : undefined,
+    recipeCuisine: 'Cocktail',
+    recipeIngredient: ingredients,
+    recipeInstructions: recipe.instructions || undefined,
+    author: {
+      '@type': 'Organization',
+      '@id': `${SITE_ORIGIN}/#org`,
+      name: 'Elixiary'
+    },
+    keywords: dedupedKeywords,
+    totalTime: recipe.total_time,
+    cookTime: recipe.cook_time,
+    nutrition: recipe.alcohol_content
+      ? {
+          '@type': 'NutritionInformation',
+          alcoholContent: recipe.alcohol_content
+        }
+      : undefined
+  });
+
+  graph.push(recipeNode);
+
+  return {
+    '@context': baseData?.['@context'] || 'https://schema.org',
+    '@graph': graph
+  };
+}
+
+function setCanonicalMeta($, canonicalUrl) {
+  const canonical = $('link[rel="canonical"]').first();
+  if (canonical.length) {
+    canonical.attr('href', canonicalUrl);
+  }
+
+  const ogUrl = $('meta[property="og:url"]').first();
+  if (ogUrl.length) {
+    ogUrl.attr('content', canonicalUrl);
+  }
+
+  const twitterUrl = $('meta[name="twitter:url"]').first();
+  if (twitterUrl.length) {
+    twitterUrl.attr('content', canonicalUrl);
+  }
+}
+
+async function cleanupStaleRecipePages(validSlugs) {
+  const distDir = path.join(__dirname, '..', 'dist');
+  let entries = [];
+  try {
+    entries = await fs.readdir(distDir, { withFileTypes: true });
+  } catch (error) {
+    console.warn('Unable to inspect dist directory for cleanup:', error.message || error);
+    return;
+  }
+
+  const reservedDirs = new Set(['assets']);
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (reservedDirs.has(entry.name)) continue;
+    if (validSlugs.has(entry.name)) continue;
+
+    const candidate = path.join(distDir, entry.name, 'index.html');
+    try {
+      await fs.access(candidate);
+    } catch (_) {
+      continue;
+    }
+
+    console.log(`Removing stale recipe page: ${entry.name}`);
+    await fs.rm(path.join(distDir, entry.name), { recursive: true, force: true });
+  }
+}
+
+async function generateRecipePages(recipes, baseHtml) {
+  if (!Array.isArray(recipes) || !recipes.length) return;
+
+  console.log('Generating static recipe detail pages...');
+
+  let baseStructuredData = null;
+  try {
+    const $ = cheerio.load(baseHtml);
+    const script = $('script[type="application/ld+json"]').first();
+    if (script.length) {
+      baseStructuredData = JSON.parse(script.html());
+    }
+  } catch (error) {
+    console.warn('Unable to parse base structured data for recipe pages:', error.message || error);
+  }
+
+  const successfulSlugs = new Set();
+
+  for (const recipe of recipes) {
+    const slug = String(recipe.slug || '').trim();
+    if (!slug) {
+      continue;
+    }
+
+    try {
+      const detail = await fetchRecipeDetail(slug);
+      const canonicalUrl = `${SITE_ORIGIN}/${encodeURIComponent(slug)}`;
+      const detailHtml = buildRecipePage(baseHtml, baseStructuredData, detail, canonicalUrl);
+
+      const outputDir = path.join(__dirname, '..', 'dist', slug);
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.html'), detailHtml, 'utf8');
+      console.log(`  • /${slug}`);
+      successfulSlugs.add(slug);
+    } catch (error) {
+      console.error(`Failed to generate static page for slug "${slug}":`, error.message || error);
+    }
+  }
+
+  const validSlugs = new Set(recipes.map((recipe) => String(recipe.slug || '').trim()).filter(Boolean));
+  await cleanupStaleRecipePages(validSlugs);
+
+  console.log(`Generated ${successfulSlugs.size} recipe detail pages.`);
+}
+
+function buildRecipePage(baseHtml, baseStructuredData, recipe, canonicalUrl) {
+  const $ = cheerio.load(baseHtml);
+
+  const pageTitle = recipe.name ? `${recipe.name} · Elixiary` : 'Elixiary';
+  $('title').first().text(pageTitle);
+
+  const description = buildRecipeDescription(recipe);
+  if (description) {
+    setMetaContent($, 'meta[name="description"]', description);
+  }
+
+  applySocialMeta($, {
+    title: pageTitle,
+    description,
+    image: recipe.image_url || recipe.image_thumb || getPlaceholderImage(recipe)
+  });
+
+  const ogType = $('meta[property="og:type"]').first();
+  if (ogType.length) {
+    ogType.attr('content', 'article');
+  }
+
+  setCanonicalMeta($, canonicalUrl);
+
+  const view = $('#view');
+  if (!view.length) {
+    throw new Error('Failed to locate #view container when building recipe page');
+  }
+  view.attr('data-prerendered', 'true');
+  view.html(buildRecipeDetailMarkup(recipe));
+
+  const structuredData = buildRecipeStructuredData(baseStructuredData, recipe);
+  const script = $('script[type="application/ld+json"]').first();
+  if (script.length) {
+    script.text(JSON.stringify(structuredData, null, 2));
+  } else {
+    $('head').append(
+      `<script type="application/ld+json">${JSON.stringify(structuredData, null, 2)}</script>`
+    );
+  }
+
+  return $.html();
+}
+
 async function main() {
   console.log('Fetching recipes from API...');
   const recipes = await fetchRecipes();
@@ -311,8 +698,11 @@ async function main() {
 
   await updateStructuredData($, recipes);
 
-  await fs.writeFile(OUTPUT_PATH, $.html(), 'utf8');
+  const updatedHomeHtml = $.html();
+  await fs.writeFile(OUTPUT_PATH, updatedHomeHtml, 'utf8');
   console.log('Successfully updated dist/index.html with prerendered content.');
+
+  await generateRecipePages(recipes, updatedHomeHtml);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- extend the prerender script to fetch individual recipes, render static detail markup, and emit canonical/meta updates for each slug
- clean up stale recipe directories and update structured data and social meta per recipe
- add a Firebase rewrite so direct slug requests hit the generated static HTML before falling back to the SPA

## Testing
- npm run prerender
- curl -s http://localhost:8080/french-pearl | head -n 5

------
https://chatgpt.com/codex/tasks/task_e_68e60c819304832aa14aea2ed5bcdc0d