### PR TITLE
Allow Firebase to serve prerendered slugs directly

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,6 @@
       { "source": "/privacy", "destination": "/privacy.html" },
       { "source": "/terms",   "destination": "/terms.html" },
       { "source": "/contact", "destination": "/contact.html" },
-      { "source": "/:slug",   "destination": "/:slug/index.html" },
       { "source": "/**",      "destination": "/index.html" }
     ],
     "headers": [


### PR DESCRIPTION
## Summary
- remove the blanket `/:slug` rewrite so Firebase Hosting can serve prerendered recipe directories directly
- rely on the existing catch-all rewrite to fall back to the SPA when a slug is missing

## Testing
- `npm run prerender`


------
https://chatgpt.com/codex/tasks/task_e_68e619079e50832a8b2c1cbf61315179