### PR TITLE
Add hero introduction to cocktail catalogue

### DIFF
--- a/dist/french-pearl/index.html
+++ b/dist/french-pearl/index.html
@@ -624,6 +624,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1783,6 +1819,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/french-sangria/index.html
+++ b/dist/french-sangria/index.html
@@ -628,6 +628,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1787,6 +1823,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/frisco-sour/index.html
+++ b/dist/frisco-sour/index.html
@@ -625,6 +625,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1784,6 +1820,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/frose/index.html
+++ b/dist/frose/index.html
@@ -623,6 +623,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1782,6 +1818,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/frosted-lemonade/index.html
+++ b/dist/frosted-lemonade/index.html
@@ -624,6 +624,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1783,6 +1819,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/frozen-cantaloupe-margarita/index.html
+++ b/dist/frozen-cantaloupe-margarita/index.html
@@ -627,6 +627,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1786,6 +1822,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/frozen-daiquiri/index.html
+++ b/dist/frozen-daiquiri/index.html
@@ -626,6 +626,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1785,6 +1821,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/frozen-mint-daiquiri/index.html
+++ b/dist/frozen-mint-daiquiri/index.html
@@ -624,6 +624,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1783,6 +1819,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/frozen-pineapple-daiquiri/index.html
+++ b/dist/frozen-pineapple-daiquiri/index.html
@@ -624,6 +624,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1783,6 +1819,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/fruit-cooler/index.html
+++ b/dist/fruit-cooler/index.html
@@ -627,6 +627,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1786,6 +1822,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/fruit-flip-flop/index.html
+++ b/dist/fruit-flip-flop/index.html
@@ -621,6 +621,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1780,6 +1816,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/fruit-shake/index.html
+++ b/dist/fruit-shake/index.html
@@ -625,6 +625,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1784,6 +1820,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">

--- a/dist/index.html
+++ b/dist/index.html
@@ -684,6 +684,42 @@
     main{padding:28px 0; min-height:calc(100vh - 200px)}
     .stack{display:flex; flex-direction:column; gap:22px}
 
+    .hero{
+      background:var(--bg);
+      border:1px solid var(--line);
+      border-radius:var(--radius);
+      padding:32px;
+      box-shadow:0 18px 40px rgba(15,23,42,.05);
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .hero-content{display:flex; flex-direction:column; gap:12px}
+
+    .hero h1{
+      margin:0;
+      font-size:32px;
+      line-height:1.1;
+      letter-spacing:-.02em;
+      color:var(--text);
+      font-weight:700;
+    }
+
+    .hero p{
+      margin:0;
+      font-size:18px;
+      line-height:1.6;
+      color:var(--muted);
+      max-width:60ch;
+    }
+
+    @media (max-width:768px){
+      .hero{padding:24px}
+      .hero h1{font-size:26px}
+      .hero p{font-size:16px}
+    }
+
     /* Filters - Responsive Collapsible */
     .filters {
       background: var(--bg);
@@ -1843,6 +1879,12 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
+      <section class="hero" aria-labelledby="hero-heading">
+        <div class="hero-content">
+          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
+          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
+        </div>
+      </section>
       <!-- Filters -->
       <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
         <div class="filters-header">


### PR DESCRIPTION
## Summary
- add a hero section to the home page introduction ahead of the filters
- style the hero block to align with the existing catalogue design
- regenerate prerendered pages so the new layout and content are reflected

## Testing
- npm run prerender

------
https://chatgpt.com/codex/tasks/task_e_68e64bd4c894832a8c41f22e470877b1