### PR TITLE
Normalize recipe durations in structured data

### DIFF
--- a/dist/french-pearl/index.html
+++ b/dist/french-pearl/index.html
@@ -111,7 +111,7 @@
       "description": "Muddle mint leaves with simple syrup in a shaker, then add gin, fresh lime juice, and absinthe. Shake well with ice and fine strain into a chilled coupe.",
       "image": "https://drive.google.com/uc?export=view&id=1es6LFkJovPLcfnclBykQ2zdt-ksMKKRo",
       "datePublished": "2025-09-29",
-      "prepTime": "4 minutes",
+      "prepTime": "PT4M",
       "recipeCategory": "Short Shaken Citrus",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/french-sangria/index.html
+++ b/dist/french-sangria/index.html
@@ -111,7 +111,7 @@
       "description": "In a large pitcher, combine red wine, brandy, simple syrup, lime juice, and Provençale blend. Add thinly sliced orange, lime, and seasonal fruits, then stir gently. Top with lemon soda before servi…",
       "image": "https://drive.google.com/uc?export=view&id=1kv1QKBzo6yZJvNIfpmTUcr4aO78mgnp2",
       "datePublished": "2025-09-29",
-      "prepTime": "2 minutes",
+      "prepTime": "PT2M",
       "recipeCategory": "Punch Party",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/frisco-sour/index.html
+++ b/dist/frisco-sour/index.html
@@ -111,7 +111,7 @@
       "description": "Combine blended whiskey, Benedictine, lemon juice, and lime juice with ice, then fine strain into a whiskey sour glass. Garnish with a slice of lemon and a slice of lime.",
       "image": "https://drive.google.com/uc?export=view&id=1rh-rJd7RULo6rfQtijMJP3OzaJ3tNG5s",
       "datePublished": "2025-09-29",
-      "prepTime": "3 minutes",
+      "prepTime": "PT3M",
       "recipeCategory": "Short Shaken Citrus",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/frose/index.html
+++ b/dist/frose/index.html
@@ -111,7 +111,7 @@
       "description": "Freeze rosé in a 13x9\" pan until nearly solid, at least 6 hours. Boil sugar with ½ cup water until dissolved, then add strawberries and let infuse for 30 minutes; strain and chill. Blend frozen ros…",
       "image": "https://drive.google.com/uc?export=view&id=1GDlFqypYurhaG5Dn-HD9gf_lwYLrlD5w",
       "datePublished": "2025-09-29",
-      "prepTime": "8 minutes",
+      "prepTime": "PT8M",
       "recipeCategory": "Frozen Blended",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/frosted-lemonade/index.html
+++ b/dist/frosted-lemonade/index.html
@@ -111,7 +111,7 @@
       "description": "Blend freshly squeezed lemon juice, sugar, water, and vanilla ice cream until smooth. Serve immediately in a chilled glass.",
       "image": "https://drive.google.com/uc?export=view&id=1SEvorCizc_GrIEXtd9yGqcmSr7qmH_tw",
       "datePublished": "2025-09-29",
-      "prepTime": "5 minutes",
+      "prepTime": "PT5M",
       "recipeCategory": "Soft Zero Proof",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/frozen-cantaloupe-margarita/index.html
+++ b/dist/frozen-cantaloupe-margarita/index.html
@@ -111,7 +111,7 @@
       "description": "Blend frozen cantaloupes, coconut milk, silver tequila, lime juice, Cointreau, and agave or honey until smooth. Optionally, rim a glass with salt and pour the mixture in.",
       "image": "https://drive.google.com/uc?export=view&id=1Yc_BKspz_ajI1G45HLtO-g6QQe2XsfFn",
       "datePublished": "2025-09-29",
-      "prepTime": "5 minutes",
+      "prepTime": "PT5M",
       "recipeCategory": "Frozen Blended",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/frozen-daiquiri/index.html
+++ b/dist/frozen-daiquiri/index.html
@@ -111,7 +111,7 @@
       "description": "Blend 1 1/2 oz light rum, 1 tbsp triple sec, 1 1/2 oz lime juice, 1 tsp sugar, and 1 cup crushed ice on low for five seconds, then on high until firm. Pour into a champagne flute, garnish with a ch…",
       "image": "https://drive.google.com/uc?export=view&id=1N4jGKOGOHhcGAR_4ur01aFxHpvW_RFt5",
       "datePublished": "2025-09-29",
-      "prepTime": "6 minutes",
+      "prepTime": "PT6M",
       "recipeCategory": "Frozen Blended",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/frozen-mint-daiquiri/index.html
+++ b/dist/frozen-mint-daiquiri/index.html
@@ -111,7 +111,7 @@
       "description": "Blend 2 oz light rum, 1 tbsp lime juice, 6 mint leaves, and 1 tsp sugar with 1 cup of crushed ice until smooth. Pour into an old-fashioned glass and serve.",
       "image": "https://drive.google.com/uc?export=view&id=1bJOtU1onqd4gMQbXkP5ASKpb4_iVfdG9",
       "datePublished": "2025-09-29",
-      "prepTime": "6 minutes",
+      "prepTime": "PT6M",
       "recipeCategory": "Frozen Blended",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/frozen-pineapple-daiquiri/index.html
+++ b/dist/frozen-pineapple-daiquiri/index.html
@@ -111,7 +111,7 @@
       "description": "Blend 1 1/2 oz light rum, 4 chunks of pineapple, 1 tbsp lime juice, and 1/2 tsp sugar with 1 cup of crushed ice until smooth. Pour into a cocktail glass and serve.",
       "image": "https://drive.google.com/uc?export=view&id=14ZTD3kgvk3B0oY4CErMW1xW6KMEaiiAm",
       "datePublished": "2025-09-29",
-      "prepTime": "6 minutes",
+      "prepTime": "PT6M",
       "recipeCategory": "Frozen Blended",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/fruit-cooler/index.html
+++ b/dist/fruit-cooler/index.html
@@ -111,7 +111,7 @@
       "description": "Toss strawberries with sugar and refrigerate overnight. Juice the lemon, reserving two slices, then mix the lemon juice, strawberries, apple juice, and soda water. In a highball glass filled with i…",
       "image": "https://drive.google.com/uc?export=view&id=1XYGWvdOtIoE9CDmlt1ec9gA5Lo-Idiwb",
       "datePublished": "2025-09-29",
-      "prepTime": "2 minutes",
+      "prepTime": "PT2M",
       "recipeCategory": "Unknown Other",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/fruit-flip-flop/index.html
+++ b/dist/fruit-flip-flop/index.html
@@ -111,7 +111,7 @@
       "description": "Blend 1 cup of yoghurt with 1 cup of fruit juice until smooth, then pour into one tall glass, two medium glasses, or three small glasses.",
       "image": "https://drive.google.com/uc?export=view&id=1DqnB-96Jw2-9MpHowkCaVu-HBbWcmaaz",
       "datePublished": "2025-09-29",
-      "prepTime": "2 minutes",
+      "prepTime": "PT2M",
       "recipeCategory": "Unknown Other",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [

--- a/dist/fruit-shake/index.html
+++ b/dist/fruit-shake/index.html
@@ -111,7 +111,7 @@
       "description": "Blend 1 cup of yoghurt, 1 banana, 4 oz of frozen orange juice, 1/2 piece of textural fruit, and 6 ice cubes until smooth. Pour into a highball glass.",
       "image": "https://drive.google.com/uc?export=view&id=14U6YwT69XKerDzUuoUW-KWVCsYuLUCzR",
       "datePublished": "2025-09-29",
-      "prepTime": "1 minute",
+      "prepTime": "PT1M",
       "recipeCategory": "Unknown Other",
       "recipeCuisine": "Cocktail",
       "recipeIngredient": [


### PR DESCRIPTION
## Summary
- add a reusable ISO 8601 duration normalizer and expose it through the frontend utilities
- update recipe JSON-LD generation to use ISO durations for prep, cook, and total time
- regenerate prerendered pages so the structured data reflects normalized durations

## Testing
- npm run prerender

------
https://chatgpt.com/codex/tasks/task_e_68e68e589ef8832ab8ff98ced8750cfc