### PR TITLE
Hide hero and filters on recipe detail pages

### DIFF
--- a/dist/assets/app.js
+++ b/dist/assets/app.js
@@ -2235,6 +2235,16 @@
         filtersEl.style.margin = '0';
         filtersEl.style.padding = '0';
       }
+
+      const heroSection = Utils.$('.hero');
+      if (heroSection) {
+        heroSection.style.display = 'none';
+        heroSection.style.visibility = 'hidden';
+        heroSection.style.height = '0';
+        heroSection.style.overflow = 'hidden';
+        heroSection.style.margin = '0';
+        heroSection.style.padding = '0';
+      }
       
     view.innerHTML = `
       <div class="detail skeleton-card">
@@ -2419,10 +2429,26 @@
       const slug = Utils.normalizeSlug(location.pathname);
       const filtersEl = Utils.$('#filters');
       const searchWrap = Utils.$('.nav-controls .search-wrap');
+      const heroSection = Utils.$('.hero');
 
       if (!slug) {
         // Home page - show filters
-        if (filtersEl) filtersEl.style.display = 'block';
+        if (filtersEl) {
+          filtersEl.style.display = '';
+          filtersEl.style.visibility = '';
+          filtersEl.style.height = '';
+          filtersEl.style.overflow = '';
+          filtersEl.style.margin = '';
+          filtersEl.style.padding = '';
+        }
+        if (heroSection) {
+          heroSection.style.display = '';
+          heroSection.style.visibility = '';
+          heroSection.style.height = '';
+          heroSection.style.overflow = '';
+          heroSection.style.margin = '';
+          heroSection.style.padding = '';
+        }
         if (searchWrap) searchWrap.style.display = '';
         if (FilterPanel && typeof FilterPanel.onListView === 'function') {
           FilterPanel.onListView();
@@ -2441,6 +2467,14 @@
           filtersEl.style.overflow = 'hidden';
           filtersEl.style.margin = '0';
           filtersEl.style.padding = '0';
+        }
+        if (heroSection) {
+          heroSection.style.display = 'none';
+          heroSection.style.visibility = 'hidden';
+          heroSection.style.height = '0';
+          heroSection.style.overflow = 'hidden';
+          heroSection.style.margin = '0';
+          heroSection.style.padding = '0';
         }
         if (FilterPanel && typeof FilterPanel.onDetailView === 'function') {
           FilterPanel.onDetailView();

--- a/dist/french-pearl/index.html
+++ b/dist/french-pearl/index.html
@@ -1819,48 +1819,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/french-sangria/index.html
+++ b/dist/french-sangria/index.html
@@ -1823,48 +1823,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/frisco-sour/index.html
+++ b/dist/frisco-sour/index.html
@@ -1820,48 +1820,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/frose/index.html
+++ b/dist/frose/index.html
@@ -1818,48 +1818,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/frosted-lemonade/index.html
+++ b/dist/frosted-lemonade/index.html
@@ -1819,48 +1819,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/frozen-cantaloupe-margarita/index.html
+++ b/dist/frozen-cantaloupe-margarita/index.html
@@ -1822,48 +1822,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/frozen-daiquiri/index.html
+++ b/dist/frozen-daiquiri/index.html
@@ -1821,48 +1821,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/frozen-mint-daiquiri/index.html
+++ b/dist/frozen-mint-daiquiri/index.html
@@ -1819,48 +1819,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/frozen-pineapple-daiquiri/index.html
+++ b/dist/frozen-pineapple-daiquiri/index.html
@@ -1819,48 +1819,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/fruit-cooler/index.html
+++ b/dist/fruit-cooler/index.html
@@ -1822,48 +1822,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/fruit-flip-flop/index.html
+++ b/dist/fruit-flip-flop/index.html
@@ -1816,48 +1816,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/dist/fruit-shake/index.html
+++ b/dist/fruit-shake/index.html
@@ -1820,48 +1820,9 @@
   <!-- Main -->
   <main id="main-content" role="main">
     <div class="container stack">
-      <section class="hero" aria-labelledby="hero-heading">
-        <div class="hero-content">
-          <h1 id="hero-heading">Discover Amazing Cocktail Recipes</h1>
-          <p>Browse a curated catalogue of handcrafted cocktails, filter by mood or ingredients, and uncover new favorites for every occasion.</p>
-        </div>
-      </section>
+      
       <!-- Filters -->
-      <section id="filters" class="filters" role="group" aria-labelledby="filters-heading" data-expanded="true">
-        <div class="filters-header">
-          <div class="filters-title">
-            <span class="filters-eyebrow">Refine results</span>
-            <h2 id="filters-heading" class="filters-heading">Filters</h2>
-          </div>
-          <div class="filters-actions">
-            <div class="results-count" aria-live="polite">
-              <span class="results-number" id="count">0</span>
-              recipes found
-            </div>
-            <button id="filters-toggle" class="filters-toggle" type="button" aria-expanded="true">
-              <span class="filters-toggle__label" data-label-collapsed="Show filters" data-label-expanded="Hide filters">Hide filters</span>
-              <span id="filters-active-count" class="filters-toggle__count" aria-hidden="true"></span>
-              <span id="filters-active-count-sr" class="sr-only">No active filters</span>
-              <svg class="filters-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div id="filters-body" class="filters-body">
-          <div id="active-filters" class="active-filters" aria-live="polite"></div>
-          <div class="filter-groups">
-            <div class="filter-section">
-              <div class="filter-label" id="category-label">Category</div>
-              <div id="cat" class="filter-chips" role="group" aria-labelledby="category-label"></div>
-            </div>
-            <div class="filter-section">
-              <div class="filter-label" id="mood-label">Mood</div>
-              <div id="mood" class="filter-chips" role="group" aria-labelledby="mood-label"></div>
-            </div>
-          </div>
-        </div>
-      </section>
+      
 
       <!-- List / Detail -->
       <div id="view" class="fade-in" role="region" aria-live="polite" aria-label="Recipe content" data-prerendered="true">

--- a/scripts/prerender-home.js
+++ b/scripts/prerender-home.js
@@ -698,6 +698,10 @@ function buildRecipePage(baseHtml, baseStructuredData, recipe, canonicalUrl) {
   if (!view.length) {
     throw new Error('Failed to locate #view container when building recipe page');
   }
+  // Remove list-only UI elements so the recipe heading is the first H1
+  $('.hero').remove();
+  $('#filters').remove();
+
   view.attr('data-prerendered', 'true');
   view.html(buildRecipeDetailMarkup(recipe));
 


### PR DESCRIPTION
## Summary
- remove the hero and filter sections when prerendering recipe detail pages so the recipe title is the lone H1
- hide/show the hero alongside filters during SPA navigation to keep runtime markup aligned with prerendering
- regenerate prerendered recipe pages with the updated structure

## Testing
- npm run prerender

------
https://chatgpt.com/codex/tasks/task_e_68e696914240832ab73d1d1b435ee14b